### PR TITLE
Remove W3C and SourceForge logos from footer

### DIFF
--- a/BETA 4/mailscanner/functions.php
+++ b/BETA 4/mailscanner/functions.php
@@ -681,10 +681,6 @@ echo $footer;
 echo '<p class="center" style="font-size:13px"><i>'."\n";
 echo page_creation_timer();
 echo '</i></p>'."\n";
-echo '<p class="center">'."\n";
-echo '        <a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Strict" height="31" width="88"></a>
-<a href="http://sourceforge.net/projects/mailwatch"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=87163&amp;type=10" width="80" height="15" alt="Get MailWatch for MailScanner at SourceForge.net. Fast, secure and Free Open Source software downloads" ></a>'."\n";
-echo '  </p>'."\n";
 echo '</body>'."\n";
 echo '</html>'."\n";
 

--- a/BETA 4/mailscanner/login.php
+++ b/BETA 4/mailscanner/login.php
@@ -69,14 +69,8 @@ if(file_exists('conf.php')){
 </td>
 </tr>
 </table>
-<p style="text-align:center;">
-    <a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Strict" height="31" width="88"></a>
-<a href="http://sourceforge.net/projects/mailwatch"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=87163&amp;type=10" width="80" height="15" alt="Get MailWatch for MailScanner at SourceForge.net. Fast, secure and Free Open Source software downloads"></a>
-	</p>
 </html>
-
 <?php
-
 }
 else{
 
@@ -101,7 +95,7 @@ else{
 <tr>
 <td colspan="3"><strong> MailWatch Login</strong></td>
 </tr>
-<td colspan="3"> Sorry the Server is missing config.conf. Please create the file by copying config.conf.example and making the required changes.</td>
+<td colspan="3"> Sorry the Server is missing conf.php. Please create the file by copying conf.php.example and making the required changes.</td>
 <tr>
 <td>&nbsp;</td>
 <td>&nbsp;</td>


### PR DESCRIPTION
This commit removes the W3C and SourceForge logos from page footer, making page load faster because of the removed connection to two external server (http://www.w3.org/Icons/valid-html401 and http://sflogo.sourceforge.net/sflogo.php?group_id=87163&type=10).
Removing SourceForge logo removes also user tracking by SourceForge.
