### PR TITLE
Fix viewpart missing message bug

### DIFF
--- a/mailscanner/viewpart.php
+++ b/mailscanner/viewpart.php
@@ -32,6 +32,7 @@ if (!isset($_GET['id'])) {
     die("No input Message ID");
 } else {
     // See if message is local
+    dbconn(); // required db link for mysql_real_escape_string
     if (!($host = @mysql_result(dbquery("SELECT hostname FROM maillog WHERE id='" . mysql_real_escape_string($_GET['id']) . "' AND " . $_SESSION["global_filter"] . ""),0))) {
         die("Message '" . $_GET['id'] . "' not found\n");
     }


### PR DESCRIPTION
added `dbconn()` (which creates a db link) before using `mysql_real_escape_string`, otherwise a null string could be returned instead of an escaped message id
