### PR TITLE
Unable to load GeoIP database to MySQL 5.5.35 and likely other versions.

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -757,7 +757,7 @@ function html_end($footer = "")
 
 function dbconn()
 {
-    $link = mysql_connect(DB_HOST, DB_USER, DB_PASS)
+    $link = mysql_connect(DB_HOST, DB_USER, DB_PASS, false, 128)
     or die ("Could not connect to database: " . mysql_error());
     mysql_select_db(DB_NAME) or die("Could not select db: " . mysql_error());
 


### PR DESCRIPTION
Change the mysql_connect() call to allow LOAD DATA INFILE to work with MySQL 5.5.35 and probably other versions.
