### PR TITLE
Fix Message Headers display for PHP 5.4+

### DIFF
--- a/mailscanner/detail.php
+++ b/mailscanner/detail.php
@@ -202,9 +202,15 @@ while ($row = mysql_fetch_array($result, MYSQL_BOTH)) {
             $row[$f] = format_mail_size($row[$f]);
         }
         if ($fieldn == "Message Headers:") {
-            $row[$f] = nl2br(
-                str_replace(array("\\n", "\t"), array("<br>", "&nbsp; &nbsp; &nbsp;"), htmlentities($row[$f]))
-            );
+            if (version_compare(phpversion(), "5.4", ">=")) {
+                $row[$f] = nl2br(
+                    str_replace(array("\n", "\t"), array("<br>", "&nbsp; &nbsp; &nbsp;"), htmlentities($row[$f], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE))
+                );
+            } else {
+                $row[$f] = nl2br(
+                    str_replace(array("\n", "\t"), array("<br>", "&nbsp; &nbsp; &nbsp;"), htmlentities($row[$f]))
+                );
+            }
             $row[$f] = preg_replace("/<br \/>/", "<br>", $row[$f]);
         }
         if ($fieldn == "SpamAssassin Autolearn:") {


### PR DESCRIPTION
Fix Message Headrers display on Details page when using PHP 5.4.0 or later.

Default charset for htlmentities changed with some breakage.

Fix uses parameters available only in PHP 5.4.0 and later, hence the conditional test
