### PR TITLE
Amend closing down messages to match reality

### DIFF
--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -87,14 +87,14 @@ sub SQLBlacklist {
 
 
 #
-# Close down the by-domain whitelist and blacklist
+# Close down the SQL whitelist and blacklist
 #
 sub EndSQLWhitelist {
-  MailScanner::Log::InfoLog("Closing down by-domain spam whitelist");
+  MailScanner::Log::InfoLog("Closing down SQL Whitelist");
 }
 
 sub EndSQLBlacklist {
-  MailScanner::Log::InfoLog("Closing down by-domain spam blacklist");
+  MailScanner::Log::InfoLog("Closing down SQL Blacklist");
 }
 
 sub CreateList {


### PR DESCRIPTION
SQL Black/whitelist closing down messages referred to the 'by-domain' spam blacklists instead of the SQL Blacklist/Whitelist
