### PR TITLE
rep_total_mail_by_date improvements

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -174,6 +174,14 @@ if (!defined('VIRUS_REGEX')) {
 ///////////////////////////////////////////////////////////////////////////////
 // Functions
 ///////////////////////////////////////////////////////////////////////////////
+function suppress_zeros($number)
+{
+	if (abs($number - 0.0) < 0.1) {
+		return '.';
+	} else {
+		return $number;
+	}
+}
 /**
  * @return string
  */
@@ -436,8 +444,8 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
     nameinfected>0
     AND (virusinfected=0 OR virusinfected IS NULL)
     AND (otherinfected=0 OR otherinfected IS NULL)
-    AND (isspam=0 OR isspam IS NULL)
-    AND (ishighspam=0 OR ishighspam IS NULL)
+    -- AND (isspam=0 OR isspam IS NULL)
+    -- AND (ishighspam=0 OR ishighspam IS NULL)
    THEN 1 ELSE 0 END
   ) AS blockedfiles,
   ROUND((
@@ -446,8 +454,8 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
      nameinfected>0
      AND (virusinfected=0 OR virusinfected IS NULL)
      AND (otherinfected=0 OR otherinfected IS NULL)
-     AND (isspam=0 OR isspam IS NULL)
-     AND (ishighspam=0 OR ishighspam IS NULL)
+     -- AND (isspam=0 OR isspam IS NULL)
+     -- AND (ishighspam=0 OR ishighspam IS NULL)
     THEN 1 ELSE 0 END
    )/COUNT(*))*100,1
   ) AS blockedfilespercent,
@@ -625,6 +633,11 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
     if (SHOW_DOC == true) {
         $nav['docs.php'] = __('documentation03');
     }
+        //Begin EFA
+        if ($_SESSION['user_type'] == 'A' && SHOW_GREYLIST == true) {
+            $nav['grey.php'] = "greylist";
+        }
+        //End EFA
     $nav['logout.php'] = __('logout03');
     //$table_width = round(100 / count($nav));
 


### PR DESCRIPTION
# changes
1. don't display 0 values
1. fix counting errors in the total mail report
1. breakout spam into how/hiigh
1. added columns for clean and blocked mail.

# screenshot of the revised report
![report-new-1](https://cloud.githubusercontent.com/assets/93068/15243210/d50e103e-192c-11e6-9966-c39148b5369b.png)

# comments
- functions.php has three changes of which only the first is necessary
  - a fix to the sql query as referenced by issue https://github.com/mailwatch/1.2.0/issues/249
  - an inelegant function to suppress the display of 0s in the report
  - a change carried over from my efa installation which can be ignored
- rep_total_mail_by_date.php
  - fixes the report query (same problem as the query in functions.php)
  - breaks spam into "high spam and slow spam"
  - adds columns for "clean" and "blocked"
  - makes the report format a little more to my own personal preference.