### PR TITLE
Modify get_disks function to work correctly on OpenVZ containers

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -1163,8 +1163,8 @@ function get_disks()
             $mounted_fs = file("/proc/mounts");
             foreach ($mounted_fs as $fs_row) {
                 $drive = preg_split("/[\s]+/", $fs_row);
-                if ((substr($drive[0], 0, 5) == '/dev/') && (stripos($drive[1], '/chroot/') === false)) {
-                    $temp_drive['device'] = $drive[0];
+		if (((substr($drive[0], 0, 5) == '/dev/') || substr($drive[0], 0, 5) == 'simfs') && (stripos($drive[1], '/chroot/') === false)) {
+                    $temp_drive['device'] = ($drive[0] == 'simfs' ? '/dev/simfs' : $drive[0]);
                     $temp_drive['mountpoint'] = $drive[1];
                     $disks[] = $temp_drive;
                     unset($temp_drive);


### PR DESCRIPTION
On the OpenVZ containers we have simfs virtual filesystem. Bash mount command is working correctly (shows /dev/simfs device) but in /proc/mounts simfs is displayed only as "simfs":

```[root@relay mailscanner]# cat /proc/mounts 
simfs / simfs rw,relatime 0 0```

This patch adds check for simfs string in /proc/mounts and if found assigns /dev/simfs to $temp_drive['device'] array item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailwatch/1.2.0/259)
<!-- Reviewable:end -->
