### PR TITLE
Fixes #348 - Bug in spam report (details.php)

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -986,7 +986,8 @@ function get_sa_rule_desc($rule)
     // Check if SA scoring is enabled
     $rule_score = '';
     if (preg_match('/^(.+) (.+)$/', $rule, $regs)) {
-        list($rule, $rule_score) = $regs;
+        $rule = $regs[1];
+        $rule_score = $regs[2];
     }
     $result = dbquery("SELECT rule, rule_desc FROM sa_rules WHERE rule='$rule'");
     $row = $result->fetch_object();


### PR DESCRIPTION
This PR fixes the bug in displaying the spam report - #348 

Bug found in `get_sa_rule_desc($rule)`

`if (preg_match('/^(.+) (.+)$/', $rule, $regs)) {
        list($rule, $rule_score) = $regs;
    }`

list function returning wrong data due to `$regs` containing 
`Array ( [0] => AWL 0.37 [1] => AWL [2] => 0.37 ) `

Also, list function appears to have different order of operation between php5 & php7 which may cause unexpected results (http://php.net/manual/en/function.list.php), better to explicitly set `$rule` and `$rule_score`