### PR TITLE
Fixes for Mailwatch.pm, SQLBlackWhiteList.pm and SQLSpamSettings.pm for utf8mb4

### DIFF
--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -1,21 +1,24 @@
 #
-#   MailWatch for MailScanner Custom Module MailWatch
+#   MailWatch for MailScanner 
+#   Custom Module MailWatch
 #
-#   Copyright (C) 2003  Steve Freegard (smf@f2s.com)
+#   Version 1.2
 #
-#   This program is free software; you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 2 of the License, or
-#   (at your option) any later version.
+# Copyright (C) 2003-2017  Steve Freegard (smf@f2s.com)
 #
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#   You should have received a copy of the GNU General Public License
-#   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
 package MailScanner::CustomConfig;
@@ -28,6 +31,11 @@ use Storable(qw[freeze thaw]);
 use POSIX;
 use Socket;
 use Encoding::FixLatin qw(fix_latin);
+
+use vars qw($VERSION);
+
+### The package version, both in 1.23 style *and* usable by MakeMaker:
+$VERSION = substr q$Revision: 1.2 $, 10;
 
 # Trace settings - uncomment this to debug
 # DBI->trace(2,'/tmp/dbitrace.log');
@@ -44,7 +52,7 @@ my ($SQLversion);
 my ($db_name) = 'mailscanner';
 my ($db_host) = 'localhost';
 my ($db_user) = 'mailwatch';
-my ($db_pass) = 'mailwatch';
+my ($db_pass) = 'k7b45d4';
 
 sub InitMailWatchLogging {
     my $pid = fork();
@@ -67,8 +75,7 @@ sub InitMailWatchLogging {
     }
 }
 
-# Check MySQL version
-sub CheckMySQLVersion {
+sub CheckSQLVersion {
     $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
         $db_user, $db_pass,
         { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
@@ -94,25 +101,24 @@ sub InitConnection {
     listen(SERVER, SOMAXCONN) or exit;
 
     # Our reason for existence - the persistent connection to the database
-    # Check if MySQL is >= 5.3.3
-    if (CheckMySQLVersion() >= 50503 ) {
+    if (CheckSQLVersion() >= 50503 ) {
         $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
-        $dbh->do('SET NAMES utf8mb4');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
+        $dbh->do('SET NAMES utf8mb4');
     } else {
         $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
-        $dbh->do('SET NAMES utf8');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
+        $dbh->do('SET NAMES utf8');
     }
 
     $sth = $dbh->prepare("INSERT INTO maillog (timestamp, id, size, from_address, from_domain, to_address, to_domain, subject, clientip, archive, isspam, ishighspam, issaspam, isrblspam, spamwhitelisted, spamblacklisted, sascore, spamreport, virusinfected, nameinfected, otherinfected, report, ismcp, ishighmcp, issamcp, mcpwhitelisted, mcpblacklisted, mcpsascore, mcpreport, hostname, date, time, headers, quarantined) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)") or
@@ -363,3 +369,4 @@ sub MailWatchLogging {
 }
 
 1;
+

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -6,7 +6,7 @@
 #
 #   Custom Module MailWatch
 #
-#   Version 1.2
+#   Version 1.5
 #
 # This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
 # License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
@@ -45,7 +45,7 @@ use Encoding::FixLatin qw(fix_latin);
 use vars qw($VERSION);
 
 ### The package version, both in 1.23 style *and* usable by MakeMaker:
-$VERSION = substr q$Revision: 1.2 $, 10;
+$VERSION = substr q$Revision: 1.5 $, 10;
 
 # Trace settings - uncomment this to debug
 # DBI->trace(2,'/tmp/dbitrace.log');

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -100,6 +100,7 @@ sub InitConnection {
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
+        $dbh->do('SET NAMES utf8mb4');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
@@ -108,6 +109,7 @@ sub InitConnection {
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
+        $dbh->do('SET NAMES utf8');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -1,8 +1,7 @@
 #
-#   MailWatch for MailScanner
-#   Copyright (C) 2003  Steve Freegard (smf@f2s.com)
+#   MailWatch for MailScanner Custom Module MailWatch
 #
-#   $Id: MailWatch.pm,v 1.0
+#   Copyright (C) 2003  Steve Freegard (smf@f2s.com)
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -31,7 +30,7 @@ use Socket;
 use Encoding::FixLatin qw(fix_latin);
 
 # Trace settings - uncomment this to debug
-# DBI->trace(2,'/var/spool/MailScanner/dbitrace.log');
+# DBI->trace(2,'/tmp/dbitrace.log');
 
 my ($dbh);
 my ($sth);

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -52,7 +52,7 @@ my ($SQLversion);
 my ($db_name) = 'mailscanner';
 my ($db_host) = 'localhost';
 my ($db_user) = 'mailwatch';
-my ($db_pass) = 'k7b45d4';
+my ($db_pass) = 'mailwatch';
 
 sub InitMailWatchLogging {
     my $pid = fork();

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -29,7 +29,7 @@ use Socket;
 use Encoding::FixLatin qw(fix_latin);
 
 # Trace settings - uncomment this to debug
-# DBI->trace(2,'/root/dbitrace.log');
+# DBI->trace(2,'/var/spool/MailScanner/dbitrace.log');
 
 my ($dbh);
 my ($sth);

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -138,7 +138,6 @@ sub InitConnection {
 sub ExitLogging {
     # Server exit - commit changes, close socket, and exit gracefully.
     close(SERVER);
-    #$dbh->commit or die $dbh->errstr;
     $dbh->disconnect;
     exit;
 }

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -1,24 +1,34 @@
 #
-#   MailWatch for MailScanner 
+# MailWatch for MailScanner
+# Copyright (C) 2003-2011  Steve Freegard (steve@freegard.name)
+# Copyright (C) 2011  Garrod Alwood (garrod.alwood@lorodoes.com)
+# Copyright (C) 2014-2017  MailWatch Team (https://github.com/mailwatch/1.2.0/graphs/contributors)
+#
 #   Custom Module MailWatch
 #
 #   Version 1.2
 #
-# Copyright (C) 2003-2017  Steve Freegard (smf@f2s.com)
+# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+# version.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# In addition, as a special exception, the copyright holder gives permission to link the code of this program with
+# those files in the PEAR library that are licensed under the PHP License (or with modified versions of those files
+# that use the same license as those files), and distribute linked combinations including the two.
+# You must obey the GNU General Public License in all respects for all of the code used other than those files in the
+# PEAR library that are licensed under the PHP License. If you modify this program, you may extend this exception to
+# your version of the program, but you are not obligated to do so.
+# If you do not wish to do so, delete this exception statement from your version.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# As a special exception, you have permission to link this program with the JpGraph library and distribute executables,
+# as long as you follow the requirements of the GNU GPL in regard to all of the software in the executable aside from
+# JpGraph.
+#
+# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
+# Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
 package MailScanner::CustomConfig;

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -1,20 +1,22 @@
 #
-# MailWatch for MailScanner
-# Copyright (C) 2003  Steve Freegard (smf@f2s.com)
+#   MailWatch for MailScanner
+#   Copyright (C) 2003  Steve Freegard (smf@f2s.com)
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+#   $Id: MailWatch.pm,v 1.0
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
 package MailScanner::CustomConfig;

--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -67,6 +67,7 @@ sub InitMailWatchLogging {
     }
 }
 
+# Check MySQL version
 sub CheckMySQLVersion {
     $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
         $db_user, $db_pass,

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -99,7 +99,6 @@ sub SQLBlacklist {
     return LookupList($message, \%Blacklist);
 }
 
-
 #
 # Close down the SQL whitelist and blacklist
 #

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -125,6 +125,7 @@ sub CreateList {
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
+        $dbh->do('SET NAMES utf8mb4');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
@@ -133,6 +134,7 @@ sub CreateList {
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
+        $dbh->do('SET NAMES utf8');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -1,6 +1,5 @@
 #
-#   MailScanner - SMTP E-Mail Virus Scanner
-#   Copyright (C) 2002  Julian Field
+#   MailWatch for MailScanner Custom Module SQLBlackWhiteList
 #
 #   $Id: SQLBlackWhiteList.pm,v 1.4 2011/12/14 18:21:28 lorodoes Exp $
 #

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -57,13 +57,13 @@ my ($db_user) = 'mailwatch';
 my ($db_pass) = 'mailwatch';
 
 # Check MySQL version
-sub CheckMySQLVersion {
+sub CheckSQLVersion {
     $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
         $db_user, $db_pass,
         { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
     );
     if (!$dbh) {
-        MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
+        MailScanner::Log::WarnLog("MailWatch: SQLBlackWhiteList:: Unable to initialise database connection: %s", $DBI::errstr);
     }
     $SQLversion = $dbh->{mysql_serverversion};
     $dbh->disconnect;
@@ -126,13 +126,13 @@ sub CreateList {
     my ($sql, $to_address, $from_address, $count, $filter);
 
     # Check if MySQL is >= 5.3.3
-    if (CheckMySQLVersion() >= 50503 ) {
+    if (CheckSQLVersion() >= 50503 ) {
         $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
         if (!$dbh) {
-            MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
+            MailScanner::Log::WarnLog("MailWatch: SQLBlackWhiteList::CreateList::: Unable to initialise database connection: %s", $DBI::errstr);
         }
         $dbh->do('SET NAMES utf8mb4');
     } else {
@@ -141,7 +141,7 @@ sub CreateList {
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
         if (!$dbh) {
-            MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
+            MailScanner::Log::WarnLog("MailWatch: SQLBlackWhiteList::CreateList::: Unable to initialise database connection: %s", $DBI::errstr);
         }
         $dbh->do('SET NAMES utf8');
     }
@@ -151,6 +151,7 @@ sub CreateList {
     $sth->execute;
     $sth->bind_columns(undef, \$to_address, \$from_address);
     $count = 0;
+    
     while($sth->fetch()) {
         $BlackWhite->{lc($to_address)}{lc($from_address)} = 1; # Store entry
         $count++;

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -1,24 +1,34 @@
 #
-#   MailWatch for MailScanner
+# MailWatch for MailScanner
+# Copyright (C) 2003-2011  Steve Freegard (steve@freegard.name)
+# Copyright (C) 2011  Garrod Alwood (garrod.alwood@lorodoes.com)
+# Copyright (C) 2014-2017  MailWatch Team (https://github.com/mailwatch/1.2.0/graphs/contributors)
+#
 #   Custom Module SQLBlackWhiteList
 #
 #   Version 1.5
 #
-# Copyright (C) 2003-2017  Steve Freegard (smf@f2s.com)
+# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+# version.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# In addition, as a special exception, the copyright holder gives permission to link the code of this program with
+# those files in the PEAR library that are licensed under the PHP License (or with modified versions of those files
+# that use the same license as those files), and distribute linked combinations including the two.
+# You must obey the GNU General Public License in all respects for all of the code used other than those files in the
+# PEAR library that are licensed under the PHP License. If you modify this program, you may extend this exception to
+# your version of the program, but you are not obligated to do so.
+# If you do not wish to do so, delete this exception statement from your version.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# As a special exception, you have permission to link this program with the JpGraph library and distribute executables,
+# as long as you follow the requirements of the GNU GPL in regard to all of the software in the executable aside from
+# JpGraph.
+#
+# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
+# Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
 package MailScanner::CustomConfig;

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -133,6 +133,7 @@ sub CreateScoreList
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
+        $dbh->do('SET NAMES utf8mb4');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
@@ -141,6 +142,7 @@ sub CreateScoreList
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
+        $dbh->do('SET NAMES utf8');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -48,14 +48,17 @@ use vars qw($VERSION);
 $VERSION = substr q$Revision: 1.5 $, 10;
 
 use DBI;
+my ($dbh);
+my ($sth);
+my ($SQLversion);
+
+# Modify this as necessary for your configuration
 my (%LowSpamScores, %HighSpamScores);
 my (%ScanList);
 my ($db_name) = 'mailscanner';
 my ($db_host) = 'localhost';
 my ($db_user) = 'mailwatch';
 my ($db_pass) = 'mailwatch';
-
-my ($SQLversion);
 
 # Check MySQL version
 sub CheckMySQLVersion {
@@ -140,7 +143,7 @@ sub EndSQLNoScan
 sub CreateScoreList
 {
     my ($type, $UserList) = @_;
-    my ($dbh, $sth, $sql, $username, $count);
+    my ($sql, $username, $count);
 
     # Check if MySQL is >= 5.3.3
     if (CheckMySQLVersion() >= 50503 ) {

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -80,19 +80,19 @@ sub CheckSQLVersion {
 sub InitSQLSpamScores
 {
     my ($entries) = CreateScoreList('spamscore', \%LowSpamScores);
-    MailScanner::Log::InfoLog("MailWatch: Read %d Spam entries", $entries);
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Read %d Spam entries", $entries);
 }
 
 sub InitSQLHighSpamScores
 {
     my $entries = CreateScoreList('highspamscore', \%HighSpamScores);
-    MailScanner::Log::InfoLog("MailWatch: Read %d high Spam entries", $entries);
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Read %d high Spam entries", $entries);
 }
 
 sub InitSQLNoScan
 {
     my $entries = CreateNoScanList('noscan', \%ScanList);
-    MailScanner::Log::InfoLog("MailWatch: Read %d No Spam Scan entries", $entries);
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Read %d No Spam Scan entries", $entries);
 }
 
 #
@@ -125,17 +125,17 @@ sub SQLNoScan
 #
 sub EndSQLSpamScores
 {
-    MailScanner::Log::InfoLog("MailWatch: Closing down MailWatch SQL Spam Scores");
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Closing down MailWatch SQL Spam Scores");
 }
 
 sub EndSQLHighSpamScores
 {
-    MailScanner::Log::InfoLog("MailWatch: Closing down MailWatch SQL High Spam Scores");
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Closing down MailWatch SQL High Spam Scores");
 }
 
 sub EndSQLNoScan
 {
-    MailScanner::Log::InfoLog("MailWatch: Closing down MailWatch SQL No Scan");
+    MailScanner::Log::InfoLog("MailWatch: SQLSpamSettings:: Closing down MailWatch SQL No Scan");
 }
 
 # Read the list of users that have defined their own Spam Score value. Also

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -1,21 +1,25 @@
 #
-#   MailWatch for MailScanner Custom Module SQLSpamSettings
+#   MailWatch for MailScanner
+#   Custom Module SQLSpamSettings
 #
-#   $Id: SQLSpamSettings.pm,v 1.4 2011/12/14 18:21:28 lorodoes Exp $
+#   Version 1.5
 #
-#   This program is free software; you can redistribute it and/or modify
-#   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 2 of the License, or
-#   (at your option) any later version.
+# Copyright (C) 2003-2017  Steve Freegard (smf@f2s.com)
 #
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#   You should have received a copy of the GNU General Public License
-#   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
 
 #
 # This module uses entries in the user table to determine the Spam Settings
@@ -31,7 +35,7 @@ no  strict 'subs'; # Allow bare words for parameter %'s
 use vars qw($VERSION);
 
 ### The package version, both in 1.23 style *and* usable by MakeMaker:
-$VERSION = substr q$Revision: 1.4 $, 10;
+$VERSION = substr q$Revision: 1.5 $, 10;
 
 use DBI;
 my (%LowSpamScores, %HighSpamScores);
@@ -133,19 +137,19 @@ sub CreateScoreList
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8mb4 => 1 }
         );
-        $dbh->do('SET NAMES utf8mb4');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
+        $dbh->do('SET NAMES utf8mb4');
     } else {
         $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
             $db_user, $db_pass,
             { PrintError => 0, AutoCommit => 1, RaiseError => 1, mysql_enable_utf8 => 1 }
         );
-        $dbh->do('SET NAMES utf8');
         if (!$dbh) {
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
+        $dbh->do('SET NAMES utf8');
     }
 
     # Connect to the database

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -44,6 +44,7 @@ my ($db_name) = 'mailscanner';
 my ($db_host) = 'localhost';
 my ($db_user) = 'mailwatch';
 my ($db_pass) = 'mailwatch';
+
 my ($SQLversion);
 
 # Check MySQL version

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -147,7 +147,7 @@ sub CreateScoreList
             MailScanner::Log::WarnLog("MailWatch: Unable to initialise database connection: %s", $DBI::errstr);
         }
     }
-    
+
     # Connect to the database
     $dbh = DBI->connect("DBI:mysql:database=$db_name;host=$db_host",
         $db_user, $db_pass,

--- a/MailScanner_perl_scripts/SQLSpamSettings.pm
+++ b/MailScanner_perl_scripts/SQLSpamSettings.pm
@@ -1,24 +1,34 @@
 #
-#   MailWatch for MailScanner
+# MailWatch for MailScanner
+# Copyright (C) 2003-2011  Steve Freegard (steve@freegard.name)
+# Copyright (C) 2011  Garrod Alwood (garrod.alwood@lorodoes.com)
+# Copyright (C) 2014-2017  MailWatch Team (https://github.com/mailwatch/1.2.0/graphs/contributors)
+#
 #   Custom Module SQLSpamSettings
 #
 #   Version 1.5
 #
-# Copyright (C) 2003-2017  Steve Freegard (smf@f2s.com)
+# This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+# version.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# In addition, as a special exception, the copyright holder gives permission to link the code of this program with
+# those files in the PEAR library that are licensed under the PHP License (or with modified versions of those files
+# that use the same license as those files), and distribute linked combinations including the two.
+# You must obey the GNU General Public License in all respects for all of the code used other than those files in the
+# PEAR library that are licensed under the PHP License. If you modify this program, you may extend this exception to
+# your version of the program, but you are not obligated to do so.
+# If you do not wish to do so, delete this exception statement from your version.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# As a special exception, you have permission to link this program with the JpGraph library and distribute executables,
+# as long as you follow the requirements of the GNU GPL in regard to all of the software in the executable aside from
+# JpGraph.
+#
+# You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
+# Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
 #


### PR DESCRIPTION
Done.

- Added support for utf8 or utf8mb4 depending of database version
- New location for dbitrace.log as MailScanner do not have the right to write in /root.
- Added version in Mailwatch.pm.
- Updated version in SQLBlackWhiteList.pm and SQLSpamSettings.pm.
- Updated disclaimer.
- Updated log messages.
- Removed #$dbh->commit; no longer used
- Works without changes in /etc/mysql/my.cnf (#430).

References: #428, #430, #345