### PR TITLE
Feature/checkconf.php

### DIFF
--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -29,15 +29,23 @@
  * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-$mailscannerRoot = "/var/www/html/mailscanner/";
+if(!isset($mailscannerRoot)) {
+    //adjust this path to the directory containing the conf.php
+    $mailscannerRoot = "/var/www/html/mailscanner/";
+}
+//this script also accepts a command line argument to set the mailscanner root folder
 if (count($argv) > 1) {
     $mailscannerRoot = $argv[1];
 }
 
-header("Content-type: text/plain\n\n");
+
+if(!headers_sent()) {
+    header("Content-type: text/plain\n\n");
+}
+
 
 //load the config file to be able to see the defined values
-require($mailscannerRoot . "conf.php");
+require_once ($mailscannerRoot . "conf.php");
 
 echo "Checking your conf.php if it contains all necessary constants" . PHP_EOL;
 

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -39,7 +39,7 @@ header("Content-type: text/plain\n\n");
 //load the config file to be able to see the defined values
 require($mailscannerRoot . "conf.php");
 
-echo "Will check your conf.php if it contains all necessary constants" . PHP_EOL;
+echo "Checking your conf.php if it contains all necessary constants" . PHP_EOL;
 
 //read the example config for constants that are missing in conf.php
 $missingConfig = '';

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -1,4 +1,5 @@
-#!/user/bin/php -q
+#!/usr/bin/php -q
+
 <?php
 
 /*

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -1,0 +1,70 @@
+#!/user/bin/php -q
+<?php
+
+/*
+ * MailWatch for MailScanner
+ * Copyright (C) 2003-2011  Steve Freegard (steve@freegard.name)
+ * Copyright (C) 2011  Garrod Alwood (garrod.alwood@lorodoes.com)
+ * Copyright (C) 2014-2017  MailWatch Team (https://github.com/orgs/mailwatch/teams/team-stable)
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * In addition, as a special exception, the copyright holder gives permission to link the code of this program with
+ * those files in the PEAR library that are licensed under the PHP License (or with modified versions of those files
+ * that use the same license as those files), and distribute linked combinations including the two.
+ * You must obey the GNU General Public License in all respects for all of the code used other than those files in the
+ * PEAR library that are licensed under the PHP License. If you modify this program, you may extend this exception to
+ * your version of the program, but you are not obligated to do so.
+ * If you do not wish to do so, delete this exception statement from your version.
+ *
+ * As a special exception, you have permission to link this program with the JpGraph library and distribute executables,
+ * as long as you follow the requirements of the GNU GPL in regard to all of the software in the executable aside from
+ * JpGraph.
+ *
+ * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+$mailscannerRoot = "/var/www/mailscanner/";
+if(count($argv) > 1) {
+    $mailscannerRoot = $argv[1];
+}
+
+header("Content-type: text/plain\n\n");
+
+//load the config file to be able to see the defined values
+require($mailscannerRoot . "conf.php");
+
+echo "Will check your conf.php if it contains all necessary constants";
+
+//read the example config for constants that are missing in conf.php
+$missingConfig = '';
+$fh = fopen($mailscannerRoot . 'conf.php.example','r');
+while ($line = fgets($fh)) {
+    $tl = trim($line);
+    if(substr($tl, 0, 8) == "define('") {
+        $arr = explode("'",$tl);
+        if(count($arr) <= 3) continue;
+        $key = $arr[1];
+        $val = $arr[3];
+        //this can show php warnings if the constant does not exist (can be ignored).
+        if(constant($key) === NULL) {
+            //constant does not exist yet
+            $missingConfig .= PHP_EOL . $line;
+        }
+    }
+}
+fclose($fh);
+
+//append the missing constants to the config file
+file_put_contents($mailscannerRoot . "conf.php", $missingConfig, FILE_APPEND);
+if ($missingConfig != '') {
+    echo "The in the warnings above mentioned constants were missing in conf.php and were added." . PHP_EOL;
+    echo "Please review the values and adjust them to you needs" . PHP_EOL;
+} else {
+    echo "All necessary constants were found" . PHP_EOL;
+}

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -1,5 +1,4 @@
 #!/usr/bin/php -q
-
 <?php
 
 /*

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -39,7 +39,7 @@ header("Content-type: text/plain\n\n");
 //load the config file to be able to see the defined values
 require($mailscannerRoot . "conf.php");
 
-echo "Will check your conf.php if it contains all necessary constants";
+echo "Will check your conf.php if it contains all necessary constants" . PHP_EOL;
 
 //read the example config for constants that are missing in conf.php
 $missingConfig = '';
@@ -48,11 +48,10 @@ while ($line = fgets($fh)) {
     $tl = trim($line);
     if (substr($tl, 0, 8) == "define('") {
         $arr = explode("'", $tl);
-        if (count($arr) <= 3) {
+        if (count($arr) < 3) {
             continue;
         }
         $key = $arr[1];
-        $val = $arr[3];
         //this can show php warnings if the constant does not exist (can be ignored)
         if (constant($key) === null) {
             //constant does not exist yet

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -43,6 +43,7 @@ echo "Will check your conf.php if it contains all necessary constants" . PHP_EOL
 
 //read the example config for constants that are missing in conf.php
 $missingConfig = '';
+$missingKeys = '';
 $fh = fopen($mailscannerRoot . 'conf.php.example', 'r');
 while ($line = fgets($fh)) {
     $tl = trim($line);
@@ -52,10 +53,10 @@ while ($line = fgets($fh)) {
             continue;
         }
         $key = $arr[1];
-        //this can show php warnings if the constant does not exist (can be ignored)
-        if (constant($key) === null) {
+        if (!defined($key)) {
             //constant does not exist yet
             $missingConfig .= PHP_EOL . $line;
+            $missingKeys .= $key . ', ';
         }
     }
 }
@@ -64,8 +65,8 @@ fclose($fh);
 //append the missing constants to the config file
 file_put_contents($mailscannerRoot . "conf.php", $missingConfig, FILE_APPEND);
 if ($missingConfig != '') {
-    echo "The in the warnings above mentioned constants were missing in conf.php and were added." . PHP_EOL;
-    echo "Please review the values and adjust them to you needs" . PHP_EOL;
+    echo "The constants $missingKeys were missing in conf.php and were added." . PHP_EOL;
+    echo "Please review the values and adjust them to your needs" . PHP_EOL;
 } else {
     echo "All necessary constants were found" . PHP_EOL;
 }

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -29,7 +29,7 @@
  * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-$mailscannerRoot = "/var/www/mailscanner/";
+$mailscannerRoot = "/var/www/html/mailscanner/";
 if (count($argv) > 1) {
     $mailscannerRoot = $argv[1];
 }

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -29,7 +29,7 @@
  * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-if(!isset($mailscannerRoot)) {
+if (!isset($mailscannerRoot)) {
     //adjust this path to the directory containing the conf.php
     $mailscannerRoot = "/var/www/html/mailscanner/";
 }
@@ -39,13 +39,13 @@ if (count($argv) > 1) {
 }
 
 
-if(!headers_sent()) {
+if (!headers_sent()) {
     header("Content-type: text/plain\n\n");
 }
 
 
 //load the config file to be able to see the defined values
-require_once ($mailscannerRoot . "conf.php");
+require_once($mailscannerRoot . "conf.php");
 
 echo "Checking your conf.php if it contains all necessary constants" . PHP_EOL;
 

--- a/mailscanner/checkconf.php
+++ b/mailscanner/checkconf.php
@@ -30,7 +30,7 @@
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 $mailscannerRoot = "/var/www/mailscanner/";
-if(count($argv) > 1) {
+if (count($argv) > 1) {
     $mailscannerRoot = $argv[1];
 }
 
@@ -43,16 +43,18 @@ echo "Will check your conf.php if it contains all necessary constants";
 
 //read the example config for constants that are missing in conf.php
 $missingConfig = '';
-$fh = fopen($mailscannerRoot . 'conf.php.example','r');
+$fh = fopen($mailscannerRoot . 'conf.php.example', 'r');
 while ($line = fgets($fh)) {
     $tl = trim($line);
-    if(substr($tl, 0, 8) == "define('") {
-        $arr = explode("'",$tl);
-        if(count($arr) <= 3) continue;
+    if (substr($tl, 0, 8) == "define('") {
+        $arr = explode("'", $tl);
+        if (count($arr) <= 3) {
+            continue;
+        }
         $key = $arr[1];
         $val = $arr[3];
-        //this can show php warnings if the constant does not exist (can be ignored).
-        if(constant($key) === NULL) {
+        //this can show php warnings if the constant does not exist (can be ignored)
+        if (constant($key) === null) {
             //constant does not exist yet
             $missingConfig .= PHP_EOL . $line;
         }

--- a/upgrade.php
+++ b/upgrade.php
@@ -31,7 +31,8 @@
  */
 
 header("Content-type: text/plain\n\n");
-require '/var/www/html/mailscanner/functions.php';
+$mailscannerRoot = '/var/www/html/mailscanner/';
+require $mailscannerRoot . 'functions.php';
 //require __DIR__ . '/mailscanner/functions.php';
 
 $link = dbconn();
@@ -487,3 +488,6 @@ if (is_array($errors)) {
     }
     echo "\n";
 }
+
+
+require $mailscannerRoot . 'checkconf.php';


### PR DESCRIPTION
adds a script to check if all necessary constants are defined in conf.php (#423)
mailscanner root folder can be passed as argument or defined in the script

The only problem with this approach is that the values of the constants cannot have line breaks in it. 
So QUARANTINE_MSG_BODY is breaking the config if it is missing
 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailwatch/1.2.0/436)
<!-- Reviewable:end -->
