### PR TITLE
possible fix for auto/unknown virus scanner

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -1156,9 +1156,9 @@ AND
     arsort($virus_array);
     reset($virus_array);
     // Get the topmost entry from the array
-    if(!defined('VIRUS_REGEX')) {
+    if (!defined('VIRUS_REGEX')) {
         return __('unknownvirusscanner03');
-    } else if ((list($key, $val) = each($virus_array)) !== '') {
+    } elseif ((list($key, $val) = each($virus_array)) !== '') {
         // Check and make sure there first placed isn't tied!
         $saved_key = $key;
         $saved_val = $val;

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -1144,7 +1144,7 @@ AND
     $result = dbquery($sql);
     $virus_array = array();
     while ($row = $result->fetch_object()) {
-        if (preg_match(VIRUS_REGEX, $row->report, $virus_reports)) {
+        if (defined('VIRUS_REGEX') && preg_match(VIRUS_REGEX, $row->report, $virus_reports)) {
             $virus = return_virus_link($virus_reports[2]);
             if (!isset($virus_array[$virus])) {
                 $virus_array[$virus] = 1;
@@ -1156,7 +1156,9 @@ AND
     arsort($virus_array);
     reset($virus_array);
     // Get the topmost entry from the array
-    if ((list($key, $val) = each($virus_array)) !== '') {
+    if(!defined('VIRUS_REGEX')) {
+        return __('unknownvirusscanner03');
+    } else if ((list($key, $val) = each($virus_array)) !== '') {
         // Check and make sure there first placed isn't tied!
         $saved_key = $key;
         $saved_val = $val;
@@ -1559,7 +1561,6 @@ function get_primary_scanner()
 {
     // Might be more than one scanner defined - pick the first as the primary
     $scanners = explode(' ', get_conf_var('VirusScanners'));
-
     return $scanners[0];
 }
 
@@ -2077,7 +2078,7 @@ function db_colorised_table($sql, $table_heading = false, $pager = false, $order
                     case 'report':
                         // IMPORTANT NOTE: for this to work correctly the 'report' field MUST
                         // appear after the 'virusinfected' field within the SQL statement.
-                        if (preg_match('/VIRUS_REGEX/', $row[$f], $virus)) {
+                        if (defined('VIRUS_REGEX') && preg_match(VIRUS_REGEX, $row[$f], $virus)) {
                             foreach ($status_array as $k => $v) {
                                 if ($v = str_replace('Virus', 'Virus (' . return_virus_link($virus[2]) . ')', $v)) {
                                     $status_array[$k] = $v;

--- a/mailscanner/languages/de.php
+++ b/mailscanner/languages/de.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 Min.:',
     'saspam03' => 'Spam',
     'sanotspam03' => 'Kein Spam',
+    'unknownvirusscanner03' => 'Virusscanner unbekannt',
 
     // 04-detail.php
     'receivedon04' => 'Empfangen um:',

--- a/mailscanner/languages/en.php
+++ b/mailscanner/languages/en.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'Spam',
     'sanotspam03' => 'Not spam',
+    'unknownvirusscanner03' => 'Unknown virus scanner',
 
     // 04-detail.php
     'receivedon04' => 'Received on:',

--- a/mailscanner/languages/fr.php
+++ b/mailscanner/languages/fr.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'Spam',
     'sanotspam03' => 'N\'est pas un Spam',
+    'unknownvirusscanner03' => 'Unknown virus scanner',
 
     // 04-detail.php
     'receivedon04' => 'Reçu le :',

--- a/mailscanner/languages/fr.php
+++ b/mailscanner/languages/fr.php
@@ -185,7 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'Spam',
     'sanotspam03' => 'N\'est pas un Spam',
-    'unknownvirusscanner03' => 'Unknown virus scanner',
+    'unknownvirusscanner03' => 'Logiciel anti virus inconnu',
 
     // 04-detail.php
     'receivedon04' => 'Reçu le :',

--- a/mailscanner/languages/it.php
+++ b/mailscanner/languages/it.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'spam',
     'sanotspam03' => 'not spam',
+    'unknownvirusscanner03' => 'Unknown virus scanner',
 
     // 04-detail.php
     'receivedon04' => 'Ricevuto il:',

--- a/mailscanner/languages/nl.php
+++ b/mailscanner/languages/nl.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'spam',
     'sanotspam03' => 'not spam',
+    'unknownvirusscanner03' => 'Unknown virus scanner',
 
     // 04-detail.php
     'receivedon04' => 'Ontvangen op:',

--- a/mailscanner/languages/pt_br.php
+++ b/mailscanner/languages/pt_br.php
@@ -185,6 +185,7 @@ return array(
     '15minutes03' => '15 min.:',
     'saspam03' => 'spam',
     'sanotspam03' => 'not spam',
+    'unknownvirusscanner03' => 'Unknown virus scanner',
 
     // 04-detail.php
     'receivedon04' => 'Recebido em:',


### PR DESCRIPTION
This should prevent error messages like #463 where an unknown virus scanner is defined or 'auto'.
It will show an info message in the report table in the top right part of the page (not shown to normal users)