### PR TITLE
Cleanup and fix in upgrade.php

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -269,7 +269,7 @@ if ($link) {
 
     // Table whitelist
     echo pad(' - Fix schema for username field in `whitelist` table');
-    $sql = 'ALTER TABLE `whitelist` CHANGE `id` `id` bigint(11) UNSIGNED NOT NULL AUTO_INCREMENT';
+    $sql = 'ALTER TABLE `whitelist` CHANGE `id` `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT';
     executeQuery($sql);
 
     // Revert back some tables to the right values due to previous errors in upgrade.php

--- a/upgrade.php
+++ b/upgrade.php
@@ -231,7 +231,7 @@ if ($link) {
     }
 
     // Update users table schema for password-reset feature
-    echo pad(' - Add resetid, resetexpire and lastreset in `users` table');
+    echo pad(' - Add resetid, resetexpire and lastreset fields in `users` table');
     if (check_column_exists('users', 'resetid') === false) {
         $sql = 'ALTER TABLE `users` ADD COLUMN (
             `resetid` varchar(32),

--- a/upgrade.php
+++ b/upgrade.php
@@ -262,6 +262,18 @@ if ($link) {
     $sql = "ALTER TABLE `users` CHANGE `username` `username` VARCHAR( 191 ) NOT NULL DEFAULT ''";
     executeQuery($sql);
 
+    echo pad(' - Fix schema for spamscore field in `users` table');
+    $sql = "ALTER TABLE `users` CHANGE `spamscore` `spamscore` float DEFAULT NULL ''";
+    executeQuery($sql);
+
+    echo pad(' - Fix schema for highspamscore field in `users` table');
+    $sql = "ALTER TABLE `users` CHANGE `highspamscore` `highspamscore` float DEFAULT NULL ''";
+    executeQuery($sql);
+
+    echo pad(' - Fix schema for noscan field in `users` table');
+    $sql = "ALTER TABLE `users` CHANGE `noscan` `noscan` float DEFAULT NULL ''";
+    executeQuery($sql);
+
     // Table user_filters
     echo pad(' - Fix schema for username field in `user_filters` table');
     $sql = "ALTER TABLE `user_filters` CHANGE `username` `username` VARCHAR( 191 ) NOT NULL DEFAULT ''";

--- a/upgrade.php
+++ b/upgrade.php
@@ -230,6 +230,19 @@ if ($link) {
         executeQuery($sql);
     }
 
+    // Update users table schema for password-reset feature
+    echo pad(' - Add resetid, resetexpire and lastreset in `users` table');
+    if (check_column_exists('users', 'resetid') === false) {
+        $sql = 'ALTER TABLE `users` ADD COLUMN (
+            `resetid` varchar(32),
+            `resetexpire` bigint(20),
+            `lastreset` bigint(20)
+            );';
+        executeQuery($sql);
+    } else {
+        echo ' ALREADY EXIST' . PHP_EOL;
+    }
+
     echo PHP_EOL;
 
     // Truncate needed for VARCHAR field used as PRIMARY or FOREIGN KEY when using UTF-8mb4
@@ -257,19 +270,7 @@ if ($link) {
     // Table whitelist
     echo pad(' - Fix schema for username field in `whitelist` table');
     $sql = 'ALTER TABLE `whitelist` CHANGE `id` `id` bigint(11) UNSIGNED NOT NULL AUTO_INCREMENT';
-
-    // Update users table schema for password-reset feature
-    echo pad(' - Updating users table for password-reset feature');
-    if (check_column_exists('users', 'resetid') === false) {
-        $sql = 'ALTER TABLE `users` ADD COLUMN (
-            `resetid` varchar(32),
-            `resetexpire` bigint(20),
-            `lastreset` bigint(20)
-            );';
-        executeQuery($sql);
-    } else {
-        echo 'ALREADY DONE' . PHP_EOL;
-    }
+    executeQuery($sql);
 
     // Revert back some tables to the right values due to previous errors in upgrade.php
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -263,15 +263,15 @@ if ($link) {
     executeQuery($sql);
 
     echo pad(' - Fix schema for spamscore field in `users` table');
-    $sql = "ALTER TABLE `users` CHANGE `spamscore` `spamscore` float DEFAULT NULL ''";
+    $sql = "ALTER TABLE `users` CHANGE `spamscore` `spamscore` float DEFAULT NULL";
     executeQuery($sql);
 
     echo pad(' - Fix schema for highspamscore field in `users` table');
-    $sql = "ALTER TABLE `users` CHANGE `highspamscore` `highspamscore` float DEFAULT NULL ''";
+    $sql = "ALTER TABLE `users` CHANGE `highspamscore` `highspamscore` float DEFAULT NULL";
     executeQuery($sql);
 
     echo pad(' - Fix schema for noscan field in `users` table');
-    $sql = "ALTER TABLE `users` CHANGE `noscan` `noscan` float DEFAULT NULL ''";
+    $sql = "ALTER TABLE `users` CHANGE `noscan` `noscan` float DEFAULT NULL";
     executeQuery($sql);
 
     // Table user_filters


### PR DESCRIPTION
```
MailWatch for MailScanner Database Upgrade to 1.2.0 - RC4

Testing connectivity to the database ................................. OK

Updating database schema:

 - Convert database to utf8........................................... ALREADY DONE

 - Drop `geoip_country` table......................................... ALREADY DROPPED
 - Drop `spamscores` table............................................ ALREADY DROPPED
 - Add autorelease table to `mailscanner` database.................... ALREADY EXIST
 - Add resetid, resetexpire and lastreset fields in `users` table..... ALREADY EXIST

 - Fix schema for username field in `audit_log` table................. OK
 - Fix schema for id field in `blacklist` table....................... OK
 - Fix schema for username field in `users` table..................... OK
 - Fix schema for spamscore field in `users` table.................... OK
 - Fix schema for highspamscore field in `users` table................ OK
 - Fix schema for noscan field in `users` table....................... OK
 - Fix schema for username field in `user_filters` table.............. OK
 - Fix schema for username field in `whitelist` table................. OK
 - Fix schema for username field in `audit_log` table................. OK
 - Fix schema for password field in `users` table..................... OK
 - Fix schema for fullname field in `users` table..................... OK
 - Fix schema for rule_desc field in `mcp_rules` table................ OK

 - Add maillog_id field and primary key to `audit_log` table.......... ALREADY DONE
 - Add inq_id field and primary key to `inq` table.................... ALREADY DONE
 - Add maillog_id field and primary key to `maillog` table............ ALREADY DONE
 - Add mtalog_id field and primary key to `mtalog` table.............. ALREADY DONE
 - Add mtalog_id field and primary key to `outq` table................ ALREADY DONE
 - Add id field and primary key to `saved_filters` table.............. ALREADY DONE
 - Add mtalog_id field and primary key to `user_filters` table........ ALREADY DONE

 - Convert database to utf8mb4........................................ ALREADY DONE

 - Convert table `audit_log` to utf8mb4............................... ALREADY CONVERTED
 - Convert table `autorelease` to utf8mb4............................. ALREADY CONVERTED
 - Convert table `blacklist` to utf8mb4............................... ALREADY CONVERTED
 - Convert table `inq` to utf8mb4..................................... ALREADY CONVERTED
 - Convert table `maillog` to utf8mb4................................. ALREADY CONVERTED
 - Convert table `mcp_rules` to utf8mb4............................... ALREADY CONVERTED
 - Convert table `mtalog` to utf8mb4.................................. ALREADY CONVERTED
 - Convert table `mtalog_ids` to utf8mb4.............................. ALREADY CONVERTED
 - Convert table `outq` to utf8mb4.................................... ALREADY CONVERTED
 - Convert table `saved_filters` to utf8mb4........................... ALREADY CONVERTED
 - Convert table `sa_rules` to utf8mb4................................ ALREADY CONVERTED
 - Convert table `users` to utf8mb4................................... ALREADY CONVERTED
 - Convert table `user_filters` to utf8mb4............................ ALREADY CONVERTED
 - Convert table `whitelist` to utf8mb4............................... ALREADY CONVERTED

 - Convert table `audit_log` to InnoDB................................ ALREADY CONVERTED
 - Convert table `autorelease` to InnoDB.............................. ALREADY CONVERTED
 - Convert table `blacklist` to InnoDB................................ ALREADY CONVERTED
 - Convert table `inq` to InnoDB...................................... ALREADY CONVERTED
 - Convert table `maillog` to InnoDB.................................. ALREADY CONVERTED
 - Convert table `mcp_rules` to InnoDB................................ ALREADY CONVERTED
 - Convert table `mtalog` to InnoDB................................... ALREADY CONVERTED
 - Convert table `mtalog_ids` to InnoDB............................... ALREADY CONVERTED
 - Convert table `outq` to InnoDB..................................... ALREADY CONVERTED
 - Convert table `saved_filters` to InnoDB............................ ALREADY CONVERTED
 - Convert table `sa_rules` to InnoDB................................. ALREADY CONVERTED
 - Convert table `users` to InnoDB.................................... ALREADY CONVERTED
 - Convert table `user_filters` to InnoDB............................. ALREADY CONVERTED
 - Convert table `whitelist` to InnoDB................................ ALREADY CONVERTED

 - Search for missing indexes......................................... DONE

Checking MailScanner.conf settings:

 - QuarantineWholeMessage ............................................ OK
 - QuarantineWholeMessagesAsQueueFiles ............................... OK
 - DetailedSpamReport ................................................ OK
 - IncludeScoresInSpamAssassinReport ................................. OK
 - SpamActions ....................................................... OK
 - HighScoringSpamActions ............................................ WARNING
 - AlwaysLookedUpLast ................................................ OK

Checking conf.php configuration entry:

 - All needed entries are OK
 - All obsolete entries are already removed

*** ERROR/WARNING SUMMARY ***
MailScanner.conf: HighScoringSpamActions != store (=delete)
```