### PR TITLE
Ignore index warnings in upgrade php

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -121,6 +121,7 @@ function get_database_charset()
     $sql = 'SELECT default_character_set_name
             FROM information_schema.schemata
             WHERE schema_name = "' . DB_NAME . '"';
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
     $result = $link->query($sql);
     $row = $result->fetch_array();
     if (null !== $row && isset($row[0])) {


### PR DESCRIPTION
Fix for the following issue in upgrade.php

```
- Convert database to utf8...........................................PHP Fatal error:  Uncaught exception 'mysqli_sql_exception' with message 'No index used in query/prepared statement SELECT default_character_set_name
            FROM information_schema.schemata
            WHERE schema_name = "mailscanner"' in /usr/src/EFA/1.2.0-develop/upgrade.php:124
Stack trace:
#0 /usr/src/EFA/1.2.0-develop/upgrade.php(124): mysqli->query('SELECT default_...')
#1 /usr/src/EFA/1.2.0-develop/upgrade.php(304): get_database_charset()
#2 {main}
  thrown in /usr/src/EFA/1.2.0-develop/upgrade.php on line 124
```
