### PR TITLE
Provides administrator the ability to combine quarantine reports into a single report

### DIFF
--- a/mailscanner/auto-release.php
+++ b/mailscanner/auto-release.php
@@ -91,7 +91,7 @@ if (file_exists('conf.php')) {
 <div class="autorelease">
     <img src="<?php echo MAILWATCH_HOSTURL . IMAGES_DIR . MW_LOGO; ?>" alt="<?php echo __('mwlogo99'); ?>">
     <div class="border-rounded">
-        <h1><?php echo __('title63'); ?></h1>
+        <h1><?php echo __('title59'); ?></h1>
         <?php
         foreach ($output as $msg) {
             echo '<p>' . $msg . '</p>';

--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -156,6 +156,8 @@ define('MAILWATCH_HOSTURL', 'http://' . rtrim(gethostname()) . '/mailscanner');
 // the clean.quarantine script provided with MailScanner.
 define('QUARANTINE_USE_FLAG', true);
 define('QUARANTINE_DAYS_TO_KEEP', 30);
+//Set QUARANTINE_FILTERS_COMBINED to true to combine quarantine report into a single report when user filters are present
+define('QUARANTINE_FILTERS_COMBINED', false);
 define('QUARANTINE_REPORT_FROM_NAME', 'MailWatch for MailScanner');
 define('QUARANTINE_REPORT_SUBJECT', 'Message Quarantine Report');
 define('QUARANTINE_SUBJECT', 'Message released from quarantine');

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -3969,6 +3969,7 @@ function checkConfVariables()
         'PROXY_TYPE',
         'PROXY_USER',
         'QUARANTINE_DAYS_TO_KEEP',
+        'QUARANTINE_FILTERS_COMBINED',
         'QUARANTINE_MSG_BODY',
         'QUARANTINE_REPORT_DAYS',
         'QUARANTINE_REPORT_FROM_NAME',

--- a/tools/Cron_jobs/mailwatch_quarantine_report.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_report.php
@@ -347,7 +347,7 @@ ORDER BY a.date DESC, a.time DESC';
                     if (count($quarantined) > 0) {
                         $list = '';
                         foreach ($quarantine_list as $item) {
-                            $list .= $item . '<br>';
+                            $list .= $item . ', ';
                         }
                         send_quarantine_email($email, $list, $quarantined);
                     }

--- a/tools/Cron_jobs/mailwatch_quarantine_report.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_report.php
@@ -345,6 +345,7 @@ ORDER BY a.date DESC, a.time DESC';
                         foreach ($quarantine_list as $item) {
                             $list .= $item . ', ';
                         }
+                        $list = substr($list,0,-2);
                         send_quarantine_email($email, $list, quarantine_sort($quarantined));
                     }
                     unset($quarantined);

--- a/tools/Cron_jobs/mailwatch_quarantine_report.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_report.php
@@ -341,11 +341,7 @@ ORDER BY a.date DESC, a.time DESC';
                         }
                     }
                     if (count($quarantined) > 0) {
-                        $list = '';
-                        foreach ($quarantine_list as $item) {
-                            $list .= $item . ', ';
-                        }
-                        $list = substr($list, 0, -2);
+                        $list = implode(', ',$quarantine_list);
                         send_quarantine_email($email, $list, quarantine_sort($quarantined));
                     }
                     unset($quarantined);

--- a/tools/Cron_jobs/mailwatch_quarantine_report.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_report.php
@@ -293,7 +293,7 @@ ORDER BY a.date DESC, a.time DESC';
             if (!empty($email) && false !== $email) {
                 dbg(" ==== Recipient e-mail address is $email");
                 // Get any additional reports required
-                $filters = array_merge(array($email), return_user_filters($user->username));
+                $filters = array_merge(array($to_address), return_user_filters($user->username));
                 if (false === QUARANTINE_FILTERS_COMBINED) {
                     foreach ($filters as $filter) {
                         if ($user->type === 'D') {


### PR DESCRIPTION
Fixes #608 

Allows administrators to combine quarantine_reports into a single report containing all of the users filters.

Fixes a bug in the case of a single report per filter, where previously each filter report received quarantine mail for the parent user as well.

