### PR TITLE
Adds the ability to show number of incoming/outcoming mails on remote server running postfix

### DIFF
--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -209,6 +209,8 @@ define('RPC_ONLY', false);
 // define('RPC_PORT', 80);
 // RPC over SSL? (defaults to port 443 unless RPC_PORT is supplied).
 // define('RPC_SSL', true);
+// Enter the remote servers as array where rpc call shall be executed at (eg. for postfix queue).
+// define('RPC_REMOTE_SERVER', array('other.example.com','other2.example.com','10.0.0.2'));
 
 // Display the inbound/outbound mail queue lengths.
 // Note: this only works with Exim and Sendmail.

--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -209,8 +209,8 @@ define('RPC_ONLY', false);
 // define('RPC_PORT', 80);
 // RPC over SSL? (defaults to port 443 unless RPC_PORT is supplied).
 // define('RPC_SSL', true);
-// Enter the remote servers as array where rpc call shall be executed at (eg. for postfix queue).
-// define('RPC_REMOTE_SERVER', array('other.example.com','other2.example.com','10.0.0.2'));
+// Enter the remote servers as space separated list where rpc call shall be executed at (eg. for postfix queue).
+// define('RPC_REMOTE_SERVER', 'other.example.com 10.0.0.2');
 
 // Display the inbound/outbound mail queue lengths.
 // Note: this only works with Exim and Sendmail.

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -423,7 +423,7 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 // Mail Queues display
                 $incomingdir = get_conf_var('incomingqueuedir', true);
                 $outgoingdir = get_conf_var('outgoingqueuedir', true);
-                if ((is_readable($incomingdir) || is_readable($outgoingdir)) ) {
+                if ((is_readable($incomingdir) || is_readable($outgoingdir))) {
                     $inq = postfixinq();
                     $outq = postfixallq() - $inq;
                 } elseif (!DISTRIBUTED_SETUP) {

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -427,6 +427,19 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 if (is_readable($incomingdir) && is_readable($outgoingdir)) {
                     $inq = postfixinq();
                     $outq = postfixallq() - $inq;
+                    if (DISTRIBUTED_SETUP && defined(RPC_REMOTE_SERVER) && !is_array(RPC_REMOTE_SERVER)) {                           
+                        for($i=0;$i<count(RPC_REMOTE_SERVER);$i++) {
+                            $msg = new xmlrpcmsg('postfix_queues');
+                            $rsp = xmlrpc_wrapper(RPC_REMOTE_SERVER[$i]); 
+                            if ($rsp->faultCode() === 0) {
+                                $response = php_xmlrpc_decode($rsp->value());                                
+                                $inq += $response['inq'];
+                                $outq += $response['outq'];                                
+                            } else {
+                                $response = 'XML-RPC Error: ' . $rsp->faultString();
+                            }
+                        }
+                    }
                     echo '    <tr><td colspan="3" class="heading" align="center">' . __('mailqueue03') . '</td></tr>' . "\n";
                     echo '    <tr><td colspan="2"><a href="postfixmailq.php">' . __('inbound03') . '</a></td><td align="right">' . $inq . '</td>' . "\n";
                     echo '    <tr><td colspan="2"><a href="postfixmailq.php">' . __('outbound03') . '</a></td><td align="right">' . $outq . '</td>' . "\n";

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -423,12 +423,13 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 // Mail Queues display
                 $incomingdir = get_conf_var('incomingqueuedir', true);
                 $outgoingdir = get_conf_var('outgoingqueuedir', true);
-                if ((!is_readable($incomingdir) || !is_readable($outgoingdir)) && !DISTRIBUTED_SETUP) {
-                    echo '    <tr><td colspan="3">' . __('verifyperm03') . ' ' . $incomingdir . ' ' . __('and03') . ' ' . $outgoingdir . '</td></tr>' . "\n";
-                } else {
+                if ((is_readable($incomingdir) || is_readable($outgoingdir)) ) {
                     $inq = postfixinq();
                     $outq = postfixallq() - $inq;
+                } elseif (!DISTRIBUTED_SETUP) {
+                    echo '    <tr><td colspan="3">' . __('verifyperm03') . ' ' . $incomingdir . ' ' . __('and03') . ' ' . $outgoingdir . '</td></tr>' . "\n";
                 }
+                
                 if (DISTRIBUTED_SETUP && defined('RPC_REMOTE_SERVER')) {
                     $pqerror = '';
                     $servers=explode(' ', RPC_REMOTE_SERVER);

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -338,7 +338,7 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
     echo '   </table>' . "\n";
     echo '  </td>' . "\n";
 
-    if ( ($_SESSION['user_type'] === 'A' || $_SESSION['user_type'] === 'D')) {
+    if (($_SESSION['user_type'] === 'A' || $_SESSION['user_type'] === 'D')) {
         echo '  <td align="center" valign="top">' . "\n";
 
         // Status table
@@ -432,7 +432,7 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 if (DISTRIBUTED_SETUP && defined('RPC_REMOTE_SERVER')) {
                     $pqerror = '';
                     $servers=explode(' ', RPC_REMOTE_SERVER);
-                    for($i=0;$i<count($servers);$i++) {
+                    for ($i=0;$i<count($servers);$i++) {
                         $msg = new xmlrpcmsg('postfix_queues', array());
                         $rsp = xmlrpc_wrapper($servers[$i], $msg);
                         if ($rsp->faultCode() === 0) {
@@ -450,7 +450,7 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 if (isset($inq) || isset($outq)) {
                     echo '    <tr><td colspan="3" class="heading" align="center">' . __('mailqueue03') . '</td></tr>' . "\n";
                     echo '    <tr><td colspan="2"><a href="postfixmailq.php">' . __('inbound03') . '</a></td><td align="right">' . $inq . '</td>' . "\n";
-                    echo '    <tr><td colspan="2"><a href="postfixmailq.php">' . __('outbound03') . '</a></td><td align="right">' . $outq . '</td>' . "\n";                    
+                    echo '    <tr><td colspan="2"><a href="postfixmailq.php">' . __('outbound03') . '</a></td><td align="right">' . $outq . '</td>' . "\n";
                 }
 
                 // Else use MAILQ from conf.php which is for Sendmail or Exim
@@ -474,7 +474,7 @@ function html_start($title, $refresh = 0, $cacheable = true, $report = false)
                 echo '    <tr><td colspan="2"><a href="mailq.php?queue=outq">' . __('outbound03') . '</a></td><td align="right">' . $outq . '</td>' . "\n";
             }
 
-            if(!DISTRIBUTED_SETUP) {
+            if (!DISTRIBUTED_SETUP) {
                 // Drive display
                 echo '    <tr><td colspan="3" class="heading" align="center">' . __('freedspace03') . '</td></tr>' . "\n";
                 foreach (get_disks() as $disk) {

--- a/mailscanner/rpcserver.php
+++ b/mailscanner/rpcserver.php
@@ -251,6 +251,17 @@ function rpc_bayes_info()
     return new xmlrpcresp(new xmlrpcval($output, 'struct'));
 }
 
+function rpc_postfix_queues()
+{
+    $inq = postfixinq();
+    $outq = postfixallq() - $inq;
+    $result = array(
+        'inq' => $inq,
+        'outq' => $outq,
+    );
+    return new xmlrpcresp(new xmlrpcval($result, 'struct'))
+}
+
 $s = new xmlrpc_server(array(
         'get_quarantine' => array(
             'function' => 'rpc_get_quarantine',
@@ -301,7 +312,12 @@ $s = new xmlrpc_server(array(
             'function' => 'rpc_bayes_info',
             'signature' => array(array('struct')),
             'docstring' => 'This service return information about the bayes database.'
-        )
+        ),
+        'postfix_queues' => array(
+            'function' => 'rpc_postfix_queues',
+            'signature' => array(array('struct')),
+            'docstring' => 'This service returns the number of mails in incoming/outgoing postfix queue.'
+        ),
     ), false);
 
 // Check that the client is authorised to connect

--- a/mailscanner/rpcserver.php
+++ b/mailscanner/rpcserver.php
@@ -256,10 +256,10 @@ function rpc_postfix_queues()
     $inq = postfixinq();
     $outq = postfixallq() - $inq;
     $result = array(
-        'inq' => $inq,
-        'outq' => $outq,
+        'inq' => new xmlrpcval($inq),
+        'outq' => new xmlrpcval($outq),
     );
-    return new xmlrpcresp(new xmlrpcval($result, 'struct'))
+    return new xmlrpcresp(new xmlrpcval($result, 'struct'));
 }
 
 $s = new xmlrpc_server(array(
@@ -315,7 +315,7 @@ $s = new xmlrpc_server(array(
         ),
         'postfix_queues' => array(
             'function' => 'rpc_postfix_queues',
-            'signature' => array(array('struct')),
+            'signature' => array(array('array')),
             'docstring' => 'This service returns the number of mails in incoming/outgoing postfix queue.'
         ),
     ), false);


### PR DESCRIPTION
It consist of three changes:

- adds the ability to force reading of MailScanner conf values by using an optional parameter (default behaviour not changed) eg. even when using distributed setup
- add rpc call that returns the number of incoming/outgoing mails when using postfix
- modify the system info (top middle table with disk space, in/out mails, etc.) to display combined number of incoming/outgoing mails on all distributed and defined postfix systems 