### PR TITLE
Adds RBL list to database, and displays relevant RBL lists in detail.php

### DIFF
--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -138,7 +138,7 @@ sub InitConnection {
         $dbh->do('SET NAMES utf8');
     }
 
-    $sth = $dbh->prepare("INSERT INTO maillog (timestamp, id, size, from_address, from_domain, to_address, to_domain, subject, clientip, archive, isspam, ishighspam, issaspam, isrblspam, spamwhitelisted, spamblacklisted, sascore, spamreport, virusinfected, nameinfected, otherinfected, report, ismcp, ishighmcp, issamcp, mcpwhitelisted, mcpblacklisted, mcpsascore, mcpreport, hostname, date, time, headers, quarantined) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)") or
+    $sth = $dbh->prepare("INSERT INTO maillog (timestamp, id, size, from_address, from_domain, to_address, to_domain, subject, clientip, archive, isspam, ishighspam, issaspam, isrblspam, spamwhitelisted, spamblacklisted, sascore, spamreport, virusinfected, nameinfected, otherinfected, report, ismcp, ishighmcp, issamcp, mcpwhitelisted, mcpblacklisted, mcpsascore, mcpreport, hostname, date, time, headers, quarantined, rblspamreport) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)") or
         MailScanner::Log::WarnLog("MailWatch: Error: %s", $DBI::errstr);
 }
 
@@ -219,7 +219,8 @@ sub ListenForMessages {
             $$message{date},
             $$message{"time"},
             $$message{headers},
-            $$message{quarantined});
+            $$message{quarantined},
+            $$message{rblspamreport});
 
         # This doesn't work in the event we have no connection by now ?
         if (!$sth) {
@@ -381,6 +382,7 @@ sub MailWatchLogging {
     $msg{"time"} = $time;
     $msg{headers} = join("\n", map { fix_latin($_)} @{$message->{headers}});
     $msg{quarantined} = $quarantined;
+    $msg{rblspamreport} = $message->{rblspamreport};
 
     # Prepare data for transmission
     my $f = freeze \%msg;

--- a/create.sql
+++ b/create.sql
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS `maillog` (
   `time` time DEFAULT NULL,
   `headers` mediumtext COLLATE utf8_unicode_ci,
   `quarantined` tinyint(1) DEFAULT '0',
+  `rblspamreport` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`maillog_id`),
   KEY `maillog_datetime_idx` (`date`,`time`),
   KEY `maillog_id_idx` (`id`(20)),

--- a/mailscanner/detail.php
+++ b/mailscanner/detail.php
@@ -92,7 +92,8 @@ $sql = "
   CASE WHEN mcpwhitelisted>0 THEN '$yes' ELSE '$no' END AS '" . __('mcpwl04') . "',
   CASE WHEN mcpblacklisted>0 THEN '$yes' ELSE '$no' END AS '" . __('mcpbl04') . "',
   mcpsascore AS '" . __('mcpscore04') . "',
-  mcpreport AS '" . __('mcprep04') . "'
+  mcpreport AS '" . __('mcprep04') . "',
+  rblspamreport AS rblspamreport
  FROM
   maillog
  WHERE
@@ -269,6 +270,15 @@ while ($row = $result->fetch_array()) {
                 continue;
             }
         }
+
+        if ($row[$f] === $yes && $fieldn === __('listedrbl04')) {
+            $row[$f] = $row[$f] . ' (' . $row['rblspamreport'] . ')';
+        }
+
+        if ($fieldn === 'rblspamreport') {
+            continue;
+        }
+
         // Handle dummy header fields
         if ($fieldn === 'HEADER') {
             // Display header

--- a/upgrade.php
+++ b/upgrade.php
@@ -439,10 +439,19 @@ if ($link) {
 
     // Add new column and index to maillog table
     echo pad(' - Add maillog_id field, rblspamreport and primary key to `maillog` table');
-    if (true === check_column_exists('maillog', 'maillog_id', 'rblspamreport')) {
+    if (true === check_column_exists('maillog', 'maillog_id')) {
         echo color(' ALREADY DONE', 'lightgreen') . PHP_EOL;
     } else {
-        $sql = 'ALTER TABLE `maillog` ADD `maillog_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`maillog_id`), ADD `rblspamreport` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL';
+        $sql = 'ALTER TABLE `maillog` ADD `maillog_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`maillog_id`)';
+        executeQuery($sql);
+    }
+
+    // Add new column to maillog table
+    echo pad(' - Add rblspamreport field to `maillog` table');
+    if (true === check_column_exists('maillog', 'rblspamreport')) {
+        echo color(' ALREADY DONE', 'lightgreen') . PHP_EOL;
+    } else {
+        $sql = 'ALTER TABLE `maillog` ADD `rblspamreport` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL';
         executeQuery($sql);
     }
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -438,11 +438,11 @@ if ($link) {
     }
 
     // Add new column and index to maillog table
-    echo pad(' - Add maillog_id field and primary key to `maillog` table');
-    if (true === check_column_exists('maillog', 'maillog_id')) {
+    echo pad(' - Add maillog_id field, rblspamreport and primary key to `maillog` table');
+    if (true === check_column_exists('maillog', 'maillog_id', 'rblspamreport')) {
         echo color(' ALREADY DONE', 'lightgreen') . PHP_EOL;
     } else {
-        $sql = 'ALTER TABLE `maillog` ADD `maillog_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`maillog_id`)';
+        $sql = 'ALTER TABLE `maillog` ADD `maillog_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`maillog_id`), ADD `rblspamreport` mediumtext COLLATE utf8_unicode_ci DEFAULT NULL';
         executeQuery($sql);
     }
 


### PR DESCRIPTION
Fixes #431 

Adds the ability to display the list of RBL's that affect a message. 
Requires a very small modification MailScanner's `Message.pm`.

PR submitted to MailScanner https://github.com/MailScanner/v5/pull/45

Code can also be found here: https://github.com/asuweb/v5/commit/b9069a9f9124930c9cf2594824019c60fe56495a

![image](https://cloud.githubusercontent.com/assets/13250955/24075555/900faaec-0c15-11e7-8613-fde8bf9639cb.png)

