### PR TITLE
Enhanced session expire handling

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -100,6 +100,17 @@ ini_set('session.cookie_httponly', 1);
 ini_set('session.use_only_cookies', 1);
 ini_set('session.use_trans_sid', 0);
 
+// Session garbage collection 5 minutes based on user activity
+// or STATUS_REFRESH + 60 sec, whichever is greater.
+
+if (defined(STATUS_REFRESH) && STATUS_REFRESH + 60 > 300) {
+    ini_set('session.gc_maxlifetime', STATUS_REFRESH + 60);
+} else {
+    ini_set('session.gc_maxlifetime', 300);
+}
+ini_set('session.gc_divisor', 1);
+ini_set('session.gc_probability', 1);
+
 $session_cookie_secure = false;
 if (SSL_ONLY === true) {
     ini_set('session.cookie_secure', 1);
@@ -108,8 +119,7 @@ if (SSL_ONLY === true) {
 
 //enforce session cookie security
 $params = session_get_cookie_params();
-session_set_cookie_params(0, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
-session_set_cookie_params(60 * 60, $params['path'], $params['domain'], $session_cookie_secure, true);
+session_set_cookie_params(0, $params['path'], $params['domain'], $session_cookie_secure, true);
 unset($session_cookie_secure);
 
 // set default timezone

--- a/mailscanner/login.php
+++ b/mailscanner/login.php
@@ -34,16 +34,6 @@
 
 require_once __DIR__ . '/functions.php';
 
-$session_cookie_secure = false;
-if (SSL_ONLY === true) {
-    ini_set('session.cookie_secure', 1);
-    $session_cookie_secure = true;
-}
-
-$params = session_get_cookie_params();
-session_set_cookie_params(0, $params['path'], $params['domain'], $session_cookie_secure, true);
-unset($session_cookie_secure);
-
 session_start();
 disableBrowserCache();
 session_regenerate_id(true);
@@ -65,6 +55,23 @@ $_SESSION['token'] = generateToken();
 } ?>
 </head>
 <body class="loginbody">
+<script>
+setInterval(function() {
+    var len1 = document.getElementById('myusername').value.length;
+    var len2 = document.getElementById('mypassword').value.length;
+
+    var prev1 = document.getElementById('myusername_length').value;
+    var prev2 = document.getElementById('mypassword_length').value;
+
+    if (len1 == prev1 && len2 == prev2) {
+        location.reload();
+    } else {
+        document.getElementById('myusername_length').value = len1;
+        document.getElementById('mypassword_length').value = len2;
+    }
+
+}, 60000);
+</script>
 <div class="login">
     <div style="text-align: center"><img src="<?php echo IMAGES_DIR . MW_LOGO; ?>" alt="<?php echo __('mwlogo99'); ?>">
     </div>
@@ -94,9 +101,11 @@ $_SESSION['token'] = generateToken();
     } ?>
                     <p><label for="myusername"><?php echo __('username'); ?></label></p>
                     <p><input name="myusername" type="text" id="myusername" autofocus></p>
+                    <input type="hidden" id="myusername_length" name="myusername_length" />
 
                     <p><label for="mypassword"><?php echo __('password'); ?></label></p>
                     <p><input name="mypassword" type="password" id="mypassword"></p>
+                    <input type="hidden" id="mypassword_length" name="mypassword_length" />
 
                     <p>
                         <button type="submit" name="Submit" value="loginSubmit"><?php echo __('login01'); ?></button>


### PR DESCRIPTION
Fixes for #662 and #708

-- Reduces the session duration to max 5 minutes for all

-- Restarts session count down on user interaction or page refresh using garbage collection technique

-- If STATUS_REFRESH + 60 > 300 then use STATUS_REFRESH + 60 instead to allow for successful page refresh with sufficient headroom.

-- Keeps login page fresh, 1 minute of inactivity will refresh page, unless user is currently typing in fields