### PR TITLE
Changes schema for nameinfected

### DIFF
--- a/create.sql
+++ b/create.sql
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS `maillog` (
   `sascore` decimal(7,2) DEFAULT '0.00',
   `spamreport` mediumtext COLLATE utf8_unicode_ci,
   `virusinfected` tinyint(1) DEFAULT '0',
-  `nameinfected` tinyint(1) DEFAULT '0',
+  `nameinfected` tinyint(2) DEFAULT '0',
   `otherinfected` tinyint(1) DEFAULT '0',
   `report` mediumtext COLLATE utf8_unicode_ci,
   `ismcp` tinyint(1) DEFAULT '0',

--- a/upgrade.php
+++ b/upgrade.php
@@ -556,6 +556,16 @@ if ($link) {
     }
     unset($maillog_timestamp_info);
 
+    // Fix schema for nameinfected to allow for >9 entries.  #981
+    echo pad(' - Fix schema for nameinfected in `maillog` table');
+    $maillog_nameinfected = getColumnInfo('maillog', 'nameinfected');
+    if ($maillog_nameinfected['Type'] !== 'tinyint(2)') {
+        $sql = 'ALTER TABLE `maillog` CHANGE `nameinfected` `nameinfected` TINYINT(2) DEFAULT 0';
+        executeQuery($sql);
+    }
+        else color('ALREADY DONE', 'lightgreen') . PHP_EOL;
+    unset($maillog_nameinfected);
+
     // Revert back some tables to the right values due to previous errors in upgrade.php
 
     // Table users password to 255

--- a/upgrade.php
+++ b/upgrade.php
@@ -562,8 +562,9 @@ if ($link) {
     if ($maillog_nameinfected['Type'] !== 'tinyint(2)') {
         $sql = 'ALTER TABLE `maillog` CHANGE `nameinfected` `nameinfected` TINYINT(2) DEFAULT 0';
         executeQuery($sql);
+    } else {
+        color('ALREADY DONE', 'lightgreen') . PHP_EOL;
     }
-        else color('ALREADY DONE', 'lightgreen') . PHP_EOL;
     unset($maillog_nameinfected);
 
     // Revert back some tables to the right values due to previous errors in upgrade.php


### PR DESCRIPTION
Changes schema for nameinfected in `maillog` table to allow for more than 9 name infections as reported by mailscanner.

Fixes #981