### PR TITLE
Display ClamAV version and status info without using MailScanner's clamav-wrapper

### DIFF
--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -43,10 +43,11 @@ if ($_SESSION['user_type'] !== 'A') {
     echo '<table class="boxtable" width="100%">';
     echo '<tr>';
     echo '<td align="center">';
-
-    // Output the information from the conf file
-    passthru(get_virus_conf('clamav') . ' . -V | awk -f ' . __DIR__ . '/clamav.awk');
-
+    // Find path to clamscan binary and run 'clamscan -V' to get version info
+    exec("which clamscan", $clamscan);
+    if (isset($clamscan[0])) {
+        passthru("$clamscan[0] -V | awk -f " . __DIR__ . '/clamav.awk');
+    }
     echo '</td>';
     echo '</tr>';
     echo '</table>';

--- a/mailscanner/sf_version.php
+++ b/mailscanner/sf_version.php
@@ -132,7 +132,10 @@ if ($_SESSION['user_type'] !== 'A') {
     // Add test for others virus scanners.
     if (preg_match('/clam/i', $virusScanner)) {
         echo 'ClamAV ' . __('version11') . ' ';
-        passthru(get_virus_conf('clamav') . " -V | cut -d/ -f1 | cut -d' ' -f2");
+        exec("which clamscan", $clamscan);
+        if (isset($clamscan[0])) {
+            passthru("$clamscan[0] -V | cut -d/ -f1 | cut -d' ' -f2");
+        }
         echo '<br>' . "\n";
     }
 


### PR DESCRIPTION
Proper fix for Issue #970 

Directly invoke 'clamscan -V' to get ClamAV version info rather than using MailScanner's clamav-wrapper.

Makes the ClamAV-related code in MailWatch simpler and avoids any permissions issues.