### PR TITLE
send empty quarantine reports over user_manager; fixes 1054

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: psr2
 
-linting: true
-
 enabled:
   - long_array_syntax
 

--- a/mailscanner/languages/de.php
+++ b/mailscanner/languages/de.php
@@ -933,6 +933,7 @@ return array(
     'message61' => 'Die Variable %s ist leer, bitte setzen Sie einen Wert in conf.php.',
     'text611' => 'Quarantäne-Bericht für %s',
     'text612' => 'In den letzten %s Tagen wurden %s empfangene E-Mails in die Quarantäne verschoben, die unten aufgeführt sind. Alle Nachrichten in der Quarantäne werden automatisch nach %s Tagen nach deren Empfang gelöscht.',
+    'text613' => 'In den letzten %s Tagen wurden keine empfangene E-Mails in die Quarantäne verschoben.',
     'release61' => 'Freigabe',
     'virus61' => 'Virus',
     'badcontent61' => 'Schlechter Inhalt',

--- a/mailscanner/languages/en.php
+++ b/mailscanner/languages/en.php
@@ -934,6 +934,7 @@ return array(
     'message61' => 'The variable %s is empty, please set a value in conf.php.',
     'text611' => 'Quarantine Report for %s',
     'text612' => 'In the last %s day(s) you have received %s e-mails that have been quarantined and are listed below. All messages in the quarantine are automatically deleted %s days after the date that they were received.',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'Release',
     'virus61' => 'Virus',
     'badcontent61' => 'Bad Content',

--- a/mailscanner/languages/fr.php
+++ b/mailscanner/languages/fr.php
@@ -933,7 +933,7 @@ return array(
     'message61' => 'La variable %s est vide. Veuillez définir cette variable dans conf.php.',
     'text611' => 'Rapport de Quarantaine pour %s',
     'text612' => 'Durant le(s) %s dernier(s) jour(s) vous avez reçu %s messages qui ont été mis en Quarantaine et dont vous retrouverez la liste ci-dessous. Les messages en Quarantaine sont automatiquement effacés %s jours après la date à laquelle ils ont été reçus.',
-    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
+    'text613' => 'Durant le(s) %s dernier(s) jour(s) vous avez reçu %s messages qui ont été mis en Quarantaine.',
     'release61' => 'Libérer',
     'virus61' => 'Virus',
     'badcontent61' => 'Contenu dangereux',

--- a/mailscanner/languages/fr.php
+++ b/mailscanner/languages/fr.php
@@ -933,6 +933,7 @@ return array(
     'message61' => 'La variable %s est vide. Veuillez définir cette variable dans conf.php.',
     'text611' => 'Rapport de Quarantaine pour %s',
     'text612' => 'Durant le(s) %s dernier(s) jour(s) vous avez reçu %s messages qui ont été mis en Quarantaine et dont vous retrouverez la liste ci-dessous. Les messages en Quarantaine sont automatiquement effacés %s jours après la date à laquelle ils ont été reçus.',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'Libérer',
     'virus61' => 'Virus',
     'badcontent61' => 'Contenu dangereux',

--- a/mailscanner/languages/it.php
+++ b/mailscanner/languages/it.php
@@ -933,6 +933,7 @@ return array(
     'message61' => 'The variable %s is empty, please set a value in conf.php.',
     'text611' => 'Quarantine Report for %s',
     'text612' => 'In the last %s day(s) you have received %s e-mails that have been quarantined and are listed below. All messages in the quarantine are automatically deleted %s days after the date that they were received.',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'Release',
     'virus61' => 'Virus',
     'badcontent61' => 'Bad Content',

--- a/mailscanner/languages/ja.php
+++ b/mailscanner/languages/ja.php
@@ -924,6 +924,7 @@ return array(
     'message61' => '変数 %s は空です。conf.php に値を設定してください。',
     'text611' => '％sの検疫レポート',
     'text612' => '最後の %s 日に隔離されたメールを受信しました。そのメールは以下のとおりです。隔離されたすべてのメールは、受信日から %s 日後に自動的に削除されます。 ',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'リリース',
     'virus61' => 'ウイルス',
     'badcontent61' => '悪いコンテンツ',

--- a/mailscanner/languages/nl.php
+++ b/mailscanner/languages/nl.php
@@ -933,6 +933,7 @@ return array(
     'message61' => 'The variable %s is empty, please set a value in conf.php.',
     'text611' => 'Quarantine Report for %s',
     'text612' => 'In the last %s day(s) you have received %s e-mails that have been quarantined and are listed below. All messages in the quarantine are automatically deleted %s days after the date that they were received.',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'Release',
     'virus61' => 'Virus',
     'badcontent61' => 'Bad Content',

--- a/mailscanner/languages/pt_br.php
+++ b/mailscanner/languages/pt_br.php
@@ -933,6 +933,7 @@ return array(
     'message61' => 'The variable %s is empty, please set a value in conf.php.',
     'text611' => 'Quarantine Report for %s',
     'text612' => 'In the last %s day(s) you have received %s e-mails that have been quarantined and are listed below. All messages in the quarantine are automatically deleted %s days after the date that they were received.',
+    'text613' => 'In the last %s day(s) you have received no e-mails that have been quarantined.',
     'release61' => 'Release',
     'virus61' => 'Virus',
     'badcontent61' => 'Bad Content',

--- a/mailscanner/user_manager.php
+++ b/mailscanner/user_manager.php
@@ -504,11 +504,13 @@ function sendReport()
     }
 
     $quarantine_report = new Quarantine_Report();
-    $reportResult = $quarantine_report->send_quarantine_reports(array($user->username));
-    if ($reportResult['succ'] >= 0) {
+    $reportResult = $quarantine_report->send_quarantine_reports(array($user->username), true);
+    if ($reportResult == -2) {
+        return getHtmlMessage(__('noReportsEnabled12'), 'error');
+    } elseif ($reportResult['succ'] > 0) {
         return getHtmlMessage(__('quarantineReportSend12'), 'success');
     } else {
-        return getHtmlMessage(__('quarantineReportFailed12'), 'success');
+        return getHtmlMessage(__('quarantineReportFailed12'), 'error');
     }
 }
 
@@ -769,7 +771,7 @@ WHEN login_expiry > " . time() . " OR login_expiry = 0 THEN CONCAT('<a href=\"?t
             if ($requirementsCheck !== true) {
                 echo getHtmlMessage(__('checkReportRequirementsFailed12'), 'error');
                 error_log('Requirements for sending quarantine reports not met: ' . $requirementsCheck);
-            } elseif (!isset($_POST['quarantine_report'])) {
+            } elseif (!isset($_POST['quarantine_report']) || $_POST['quarantine_report'] !== 'on') {
                 echo getHtmlMessage(__('noReportsEnabled12'), 'error');
             } else {
                 $quarantine_report = new Quarantine_Report();


### PR DESCRIPTION
Problem exists if there are no quarantined mails for the user (currently generates an php error)

This PR adds checks to prevent that error and enables sending of empty reports over user_manager.
fixes #1054