### PR TITLE
Simplify ClamAV version detection

### DIFF
--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -44,8 +44,11 @@ if ($_SESSION['user_type'] !== 'A') {
     echo '<tr>';
     echo '<td align="center">';
 
-    // Output the information from the conf file
-    passthru(\MailWatch\Antivirus::getAntivirusConf('clamav') . ' . -V | awk -f ' . __DIR__ . '/clamav.awk');
+    // get version info from clamscan
+    exec('which clamscan', $clamscan);
+    if (isset($clamscan[0])) {
+        passthru("$clamscan[0] -V | awk -f " . __DIR__ . '/clamav.awk');
+    }
 
     echo '</td>';
     echo '</tr>';

--- a/mailscanner/sf_version.php
+++ b/mailscanner/sf_version.php
@@ -134,8 +134,11 @@ if ($_SESSION['user_type'] !== 'A') {
 
     // Add test for others virus scanners.
     if (preg_match('/clam/i', $virusScanner)) {
-        echo 'ClamAV ' . \MailWatch\Translation::__('version11') . ' ';
-        passthru(\MailWatch\Antivirus::getAntivirusConf('clamav') . " -V | cut -d/ -f1 | cut -d' ' -f2");
+        echo 'ClamAV ' . __('version11') . ' ';
+        exec('which clamscan', $clamscan);
+        if (isset($clamscan[0])) {
+            passthru("$clamscan[0] -V | cut -d/ -f1 | cut -d' ' -f2");
+        }
         echo '<br>' . "\n";
     }
 


### PR DESCRIPTION
Detect ClamAV versions by invoking clamscan and not indirectly using MailScanner's configuration