### PR TITLE
Use utf8 for values of the column mailscanner.maillog.report

### DIFF
--- a/MailScanner_perl_scripts/MailWatch.pm
+++ b/MailScanner_perl_scripts/MailWatch.pm
@@ -319,6 +319,8 @@ sub MailWatchLogging {
         $text =~ s/\t/ /g;  # and no TAB characters
         $text =~ s/\r/ /g;  # and no CR characters
 
+        utf8::upgrade($text);
+
         # Uncommet the folloging line when debugging MailWatch.pm
         #MailScanner::Log::WarnLog("MailWatch: Debug: VAR text: %s", Dumper($text));
 


### PR DESCRIPTION
Hello,

### Preface

Today I have encountered the error below:

```
Sep 18 12:21:58 efa-02 MailScanner[1877]: Could not use Custom Function code MailScanner::CustomConfig::InitMailWatchLogging, it could not be "eval"ed. Make sure the module is correct with perl -wc (Error: DBD::mysql::st execute failed: Incorrect string value: '\xD1.exe)...' for column `mailscanner`.`maillog`.`report` at row 1 at /usr/share/MailScanner/perl/custom/MailWatch.pm line 185, <CLIENT> line 9475.
```

### Details

In the database `mailscanner`, the table `maillog`, the column `report` expect the value in utf8, but the insert to the table may failed as was shown above.

```
MariaDB [mailscanner]> SELECT TABLE_NAME,COLUMN_NAME,CHARACTER_SET_NAME FROM information_schema.`COLUMNS` WHERE TABLE_NAME = 'maillog' AND COLUMN_NAME = 'report';
+------------+-------------+--------------------+
| TABLE_NAME | COLUMN_NAME | CHARACTER_SET_NAME |
+------------+-------------+--------------------+
| maillog    | report      | utf8mb4            |
+------------+-------------+--------------------+
1 row in set (0.00 sec)
```

The patch just corrects the string to match utf8 bytes.

### Installation notes

MailWatch for MailScanner v1.2.7-dev running on EFA-3.0.2.6

### References:

1. https://perldoc.perl.org/utf8.html

Thanks!