### PR TITLE
Allow passing the argument --max-size 0 to sa-learn

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -3762,7 +3762,7 @@ function quarantine_learn($list, $num, $type, $rpc_only = false)
             } else {
                 // Only sa-learn required
                 $max_size_option = '';
-                if (defined('SA_MAXSIZE') && is_int(SA_MAXSIZE) && SA_MAXSIZE > 0) {
+                if (defined('SA_MAXSIZE') && is_int(SA_MAXSIZE) && SA_MAXSIZE >= 0) {
                     $max_size_option = ' --max-size ' . SA_MAXSIZE;
                 }
 


### PR DESCRIPTION
Hello,

In the SpamAssassin's documentation has been said:
```
 --max-size <b>        Skip messages larger than b bytes;
                       defaults to 256 KB, 0 implies no limit
```

But, MailWatch currently ignores any value less and equal than zero. This patch fix the issue.

Thank you!

**Reference** https://spamassassin.apache.org/full/3.4.x/doc/sa-learn.html