### PR TITLE
fix mailwatch_quarantine_report.php for php >7.0

### DIFF
--- a/tools/Cron_jobs/mailwatch_quarantine_report.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_report.php
@@ -38,7 +38,7 @@ require_once MAILWATCH_HOME . '/quarantine_report.inc.php';
 $usersForReport = array();
 if (isset($argv) && count($argv) > 1) {
     //get path from command line argument if set
-    $usersForReport = split(',', $argv[1]);
+    $usersForReport = explode(',', $argv[1]);
 }
 $report = new Quarantine_Report();
 $requirements_met = Quarantine_Report::check_quarantine_report_requirements();


### PR DESCRIPTION
split is deprecated since php 7