### PR TITLE
Fix TLD check in whitelist / blacklist

### DIFF
--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -206,7 +206,7 @@ sub LookupList {
     #   e.g. me@this.that.example.com generates subdomain/tld list of ('that.example.com', 'example.com', 'com')
     $subdom = $fromdomain;
     @subdomains = ();
-    while ($subdom =~ /.*?\.(.*)/) {
+    while ($subdom =~ /.*?\.(.*\.(\w+))$/) {
         $subdom = $1;
         push (@subdomains, "*.".$subdom);
     }

--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -206,7 +206,7 @@ sub LookupList {
     #   e.g. me@this.that.example.com generates subdomain/tld list of ('that.example.com', 'example.com', 'com')
     $subdom = $fromdomain;
     @subdomains = ();
-    while ($subdom =~ /.*?\.(.*\.(\w+))$/) {
+    while ($subdom =~ /(?:.*?\.(.*\.(\w+))$|.*\.(\w+)$)/) {
         $subdom = $1;
         push (@subdomains, "*.".$subdom);
     }


### PR DESCRIPTION
This should fix the lack of TLD support for the blacklist and whitelist of mailwatch.  regex validated using validator.

mail.example.com
gets broken down to 
mail.google.com
google.com
com
instead of just
mail.google.com
google.com