### PR TITLE
Fix rule_name formatting in sa_rules_update.php

### DIFF
--- a/mailscanner/sa_rules_update.php
+++ b/mailscanner/sa_rules_update.php
@@ -67,7 +67,7 @@ if ($_SESSION['user_type'] !== 'A') {
             // debug("line: ".$line."\n");
             preg_match("/^(?:\s*)describe\s+(\S+)\s+(.+)$/", $line, $regs);
             if (isset($regs[1], $regs[2])) {
-                $rule_name = htmlentities(trim($regs[1]), ENT_NOQUOTES | ENT_HTML5, 'UTF-8');
+                $rule_name = trim($regs[1]);
                 $rule_desc = htmlentities(trim(strip_tags($regs[2])), ENT_NOQUOTES | ENT_HTML5, 'UTF-8');
                 echo '<tr><td>' . $rule_name . '</td><td>' . $rule_desc . "</td></tr>\n";
                 $rule_name = safe_value($rule_name);


### PR DESCRIPTION
htmlentities() should only be applied to rule_desc, not rule_name as it breaks the rule descriptions in details.php.