### PR TITLE
msre: fix status message after mailscanner reload

### DIFF
--- a/mailscanner/msre_edit.php
+++ b/mailscanner/msre_edit.php
@@ -722,7 +722,7 @@ function Process_Form($file_contents, $short_filename)
     if (!$fh) {
         $status_msg .= '<span class="error">' . __('error0155') . '</span><br>' . "\n";
     } else {
-        $status_msg .= __('error55') . '<br>' . "\n" . sprintf(__('message55'), MSRE_RELOAD_INTERVAL) . '<br>' . "\n";
+        $status_msg .= __('ok55') . '<br>' . "\n" . sprintf(__('message55'), MSRE_RELOAD_INTERVAL) . '<br>' . "\n";
     }
     $status_msg .= "</span>\n";
 


### PR DESCRIPTION
the else case is the good case, so it should give us a positive status message (not an error!) 
'error55' isn't even defined in the language files.
