### PR TITLE
improve performance of mailwatch_milter_relay.php

### DIFF
--- a/tools/Postfix_relay/mailwatch_milter_relay.php
+++ b/tools/Postfix_relay/mailwatch_milter_relay.php
@@ -47,7 +47,6 @@ $idqueue = [];
 
 function doit($input)
 {
-    global $fp;
     if (!$fp = popen($input, 'r')) {
         exit(__('diepipe54'));
     }
@@ -68,7 +67,7 @@ function follow($file)
         clearstatcache();
         $currentSize = filesize($file);
         if ($size == $currentSize) {
-            sleep(1);
+            sleep(5);
             continue;
         }
 
@@ -161,13 +160,14 @@ function process_sql()
             @$smtpd_id = $result->fetch_row()[0];
 
             if (DEBUG_MILTER === true) {
-                syslog(LOG_MAIL | LOG_DEBUG, 'milter_relay: '.$i.' / '.$smtp_id.' / '.$message_id.' / '.$to.' => '.$smtpd_id);
+                syslog(LOG_MAIL | LOG_DEBUG, 'milter_relay: idqueue '.$i.' of '.($idcount - 1).' / '.$smtp_id.' / '.$message_id.' / '.$to.' => '.$smtpd_id);
             }
 
             // Find correllating ids and update table, drop from queue
             if (isset($smtpd_id) && $smtpd_id !== $smtp_id) {
                 dbquery("REPLACE INTO `mtalog_ids` VALUES ('" . $smtpd_id . "','" . $smtp_id . "')");
                 array_splice($idqueue, $i, 1);
+                --$i;
                 $idcount = count($idqueue);
                 if (DEBUG_MILTER === true) {
                     syslog(LOG_MAIL | LOG_DEBUG, 'milter_relay: maillog hit for ' . $smtp_id . ' entry logged and removed from queue');
@@ -187,9 +187,10 @@ function remove_entry($id)
         if (time() > $idqueue[$i][2] + QUEUETIMEOUT) {
             // Drop expired entry from queue
             if (DEBUG_MILTER === true) {
-                syslog(LOG_MAIL | LOG_DEBUG, 'milter_relay: Expiring smtpid ' . $idqueue[$i][1] . ' after ' . QUEUETIMEOUT . ' seconds');
+                syslog(LOG_MAIL | LOG_DEBUG, 'milter_relay: Expiring smtpid ' . $idqueue[$i][0] . ' after ' . QUEUETIMEOUT . ' seconds');
             }
             array_splice($idqueue, $i, 1);
+            --$i;
             $idcount = count($idqueue);
             continue;
         }


### PR DESCRIPTION
the code part which executes the SQL commands does not need to run after each line from the logfile is processed.
instead it is sufficient to run SQL statements once after logfile is analyzed and relevant data was read into $idqueue array.
so I moved this part into a separate function. 
this is a quite simple but very performance-effective change.
