### PR TITLE
fix bulk msg operations with milter mode

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -3965,7 +3965,7 @@ function quarantine_delete($list, $num, $rpc_only = false)
 function fixMessageId($id)
 {
     $mta = get_conf_var('mta');
-    if ('postfix' === $mta) {
+    if (('postfix' === $mta) || ('msmail' === $mta)) {
         $id = str_replace('_', '.', $id);
     }
 


### PR DESCRIPTION
bulk message operations do not work when mailscanner is working in milter mode.
we need to 'fixMessageId' also when mta is 'msmail'.

otherwise in 'do_message_ops.php' the 'validateInput' returns negative and the execution is stopped.