### PR TITLE
enhancement for optionally hiding nonspams on quarantine display

### DIFF
--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -298,6 +298,9 @@ define('HIDE_NON_SPAM', false);
 // Hide Unknown Mail from quarantine reports
 define('HIDE_UNKNOWN', false);
 
+// Apply hide options above also to quarantine page
+define('HIDE_APPLY_QUARANTINE', false);
+
 // Quarantine Auto Release
 // Set true to allow auto release of quarantined items from quarantine report.
 define('AUTO_RELEASE', false);

--- a/mailscanner/quarantine.php
+++ b/mailscanner/quarantine.php
@@ -40,6 +40,50 @@ if (!isset($_GET['dir'])) {
         echo '<tr><th colspan=2>' . __('folder08') . '</th></tr>' . "\n";
         foreach ($dates as $date) {
             $sql = 'SELECT id FROM maillog WHERE ' . $_SESSION['global_filter'] . " AND date='$date' AND quarantined=1";
+
+            // Hide high spam/mcp from regular users if enabled
+            if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && 'U' === $_SESSION['user_type']) {
+                $sql .= '
+    AND
+     ishighspam=0
+    AND
+     COALESCE(ishighmcp,0)=0';
+            }
+
+            // Hide non-spam from regular users if enabled
+            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+                $sql .= '
+    AND 
+     isspam>0';
+            }
+
+            // Hide unknown (clean) messages if enabled
+            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+                $sql .= '
+    AND
+    (
+     virusinfected>0
+     OR
+     nameinfected>0
+     OR
+     otherinfected>0
+     OR
+     ishighspam>0
+     OR
+     isrblspam>0
+     OR
+     spamblacklisted>0
+     OR
+     ismcp>0
+     OR
+     ishighmcp>0
+     OR
+     issamcp>0
+     OR
+     isspam>0
+    )';
+            }
+
             $result = dbquery($sql);
             $rowcnt = $result->num_rows;
             $rowstr = '  ----------';
@@ -143,6 +187,40 @@ AND
      COALESCE(ishighmcp,0)=0';
         }
 
+        // Hide non-spam from regular users if enabled
+        if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+            $sql .= '
+    AND 
+     isspam>0';
+        }
+
+        // Hide unknown (clean) messages if enabled
+        if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+            $sql .= '
+    AND
+    (
+     virusinfected>0
+     OR
+     nameinfected>0
+     OR
+     otherinfected>0
+     OR
+     ishighspam>0
+     OR
+     isrblspam>0
+     OR
+     spamblacklisted>0
+     OR
+     ismcp>0
+     OR
+     ishighmcp>0
+     OR
+     issamcp>0
+     OR
+     isspam>0
+    )';
+        }
+
         $sql .= '
 ORDER BY
  date DESC, time DESC';
@@ -200,6 +278,40 @@ ORDER BY
      ishighspam=0
     AND
      COALESCE(ishighmcp,0)=0';
+            }
+
+            // Hide non-spam from regular users if enabled
+            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+                $sql .= '
+    AND 
+     isspam>0';
+            }
+
+            // Hide unknown (clean) messages if enabled
+            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+                $sql .= '
+    AND
+    (
+     virusinfected>0
+     OR
+     nameinfected>0
+     OR
+     otherinfected>0
+     OR
+     ishighspam>0
+     OR
+     isrblspam>0
+     OR
+     spamblacklisted>0
+     OR
+     ismcp>0
+     OR
+     ishighmcp>0
+     OR
+     issamcp>0
+     OR
+     isspam>0
+    )';
             }
 
             $sql .= '

--- a/mailscanner/quarantine.php
+++ b/mailscanner/quarantine.php
@@ -42,7 +42,7 @@ if (!isset($_GET['dir'])) {
             $sql = 'SELECT id FROM maillog WHERE ' . $_SESSION['global_filter'] . " AND date='$date' AND quarantined=1";
 
             // Hide high spam/mcp from regular users if enabled
-            if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && 'U' === $_SESSION['user_type']) {
+            if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
                 $sql .= '
     AND
      ishighspam=0
@@ -51,14 +51,14 @@ if (!isset($_GET['dir'])) {
             }
 
             // Hide non-spam from regular users if enabled
-            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
                 $sql .= '
     AND 
      isspam>0';
             }
 
             // Hide unknown (clean) messages if enabled
-            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true) {
                 $sql .= '
     AND
     (
@@ -179,7 +179,7 @@ AND
  quarantined = 1";
 
         // Hide high spam/mcp from regular users if enabled
-        if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && 'U' === $_SESSION['user_type']) {
+        if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
             $sql .= '
     AND
      ishighspam=0
@@ -188,14 +188,14 @@ AND
         }
 
         // Hide non-spam from regular users if enabled
-        if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+        if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
             $sql .= '
     AND 
      isspam>0';
         }
 
         // Hide unknown (clean) messages if enabled
-        if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+        if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true) {
             $sql .= '
     AND
     (
@@ -272,7 +272,7 @@ ORDER BY
    BINARY id IN ($msg_ids)";
 
             // Hide high spam/mcp from regular users if enabled
-            if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && 'U' === $_SESSION['user_type']) {
+            if (defined('HIDE_HIGH_SPAM') && HIDE_HIGH_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
                 $sql .= '
     AND
      ishighspam=0
@@ -281,14 +281,14 @@ ORDER BY
             }
 
             // Hide non-spam from regular users if enabled
-            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && 'U' === $_SESSION['user_type']) {
+            if (defined('HIDE_NON_SPAM') && HIDE_NON_SPAM === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true && 'U' === $_SESSION['user_type']) {
                 $sql .= '
     AND 
      isspam>0';
             }
 
             // Hide unknown (clean) messages if enabled
-            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true) {
+            if (defined('HIDE_UNKNOWN') && HIDE_UNKNOWN === true && defined('HIDE_APPLY_QUARANTINE') && HIDE_APPLY_QUARANTINE === true) {
                 $sql .= '
     AND
     (


### PR DESCRIPTION
enhance quarantine.php display to regard all **HIDE_...** configuration options like quarantine_report.inc.php does.

this is especially useful when you have Mailscanner configured like this:
`Non Spam Actions = store-nonspam ...`

Then you can get only the relevant quarantine to display with mailwatch config:
`define('HIDE_UNKNOWN', true);`
