### PR TITLE
improve quarantine_report

### DIFF
--- a/mailscanner/quarantine_report.inc.php
+++ b/mailscanner/quarantine_report.inc.php
@@ -358,8 +358,8 @@ ORDER BY a.date DESC, a.time DESC';
         $filters = array_merge([$to_address], self::return_user_filters($username));
         if (QUARANTINE_FILTERS_COMBINED === false) {
             $sendResult = false;
-			
-			if ('A' === $type) {
+
+            if ('A' === $type) {
                 $list_for = gethostname();
 
                 self::dbg(" ==== Building list for $list_for");
@@ -390,7 +390,7 @@ ORDER BY a.date DESC, a.time DESC';
                     }
                     unset($quarantined);
                 }
-			}
+            }
 
             return $sendResult;
         } else {

--- a/mailscanner/quarantine_report.inc.php
+++ b/mailscanner/quarantine_report.inc.php
@@ -402,10 +402,10 @@ ORDER BY a.date DESC, a.time DESC';
                 $list_for = gethostname();
 
                 self::dbg(" ==== Building list for $list_for");
-                $quarantined = self::return_quarantine_list_array('', '');
+                $quarantined[] = self::return_quarantine_list_array('', '');
                 $quarantine_list[] = $list_for;
 
-                self::dbg(' ==== Found ' . count($quarantined) . ' quarantined e-mails');
+                self::dbg(' ==== Found ' . count($quarantined[0]) . ' quarantined e-mails');
             }
             else {
                 foreach ($filters as $filter) {

--- a/mailscanner/quarantine_report.inc.php
+++ b/mailscanner/quarantine_report.inc.php
@@ -358,27 +358,39 @@ ORDER BY a.date DESC, a.time DESC';
         $filters = array_merge([$to_address], self::return_user_filters($username));
         if (QUARANTINE_FILTERS_COMBINED === false) {
             $sendResult = false;
-            foreach ($filters as $filter) {
-                if ('D' === $type) {
-                    $filter_domain = preg_match('/(\S+)@(\S+)/', $filter, $split) ? $split[2] : $filter;
-                    $list_for = $filter_domain;
-                } elseif ('A' === $type) {
-                    $filter_domain = '';
-                    $filter = '';
-                    $list_for = '';
-                } else {
-                    $filter_domain = $to_domain;
-                    $list_for = $filter;
-                }
+			
+			if ('A' === $type) {
+                $list_for = gethostname();
 
                 self::dbg(" ==== Building list for $list_for");
-                $quarantined = self::return_quarantine_list_array($filter, $filter_domain);
+                $quarantined = self::return_quarantine_list_array('', '');
                 self::dbg(' ==== Found ' . count($quarantined) . ' quarantined e-mails');
+
                 if (true === $sendEmptyReports || count($quarantined) > 0) {
                     $sendResult = self::send_quarantine_email($email, $list_for, $quarantined);
                 }
                 unset($quarantined);
             }
+            else {
+                foreach ($filters as $filter) {
+                    if ('D' === $type) {
+                        $filter_domain = preg_match('/(\S+)@(\S+)/', $filter, $split) ? $split[2] : $filter;
+                        $list_for = $filter_domain;
+                    } else {
+                        $filter_domain = $to_domain;
+                        $list_for = $filter;
+                    }
+
+                    self::dbg(" ==== Building list for $list_for");
+                    $quarantined = self::return_quarantine_list_array($filter, $filter_domain);
+                    self::dbg(' ==== Found ' . count($quarantined) . ' quarantined e-mails');
+				
+                    if (true === $sendEmptyReports || count($quarantined) > 0) {
+                        $sendResult = self::send_quarantine_email($email, $list_for, $quarantined);
+                    }
+                    unset($quarantined);
+                }
+			}
 
             return $sendResult;
         } else {
@@ -386,26 +398,33 @@ ORDER BY a.date DESC, a.time DESC';
             $quarantine_list = [];
             $quarantined = [];
 
-            foreach ($filters as $filter) {
-                if ('D' === $type) {
-                    $filter_domain = preg_match('/(\S+)@(\S+)/', $filter, $split) ? $split[2] : $filter;
-                    $list_for = $filter_domain;
-                } elseif ('A' === $type) {
-                    $filter_domain = '';
-                    $filter = '';
-                    $list_for = '';
-                } else {
-                    $filter_domain = $to_domain;
-                    $list_for = $filter;
-                }
+            if ('A' === $type) {
+                $list_for = gethostname();
 
-                $quarantine_list[] = $list_for;
                 self::dbg(" ==== Building list for $list_for");
-                $tmp_quarantined = self::return_quarantine_list_array($filter, $filter_domain);
+                $quarantined = self::return_quarantine_list_array('', '');
+                $quarantine_list[] = $list_for;
 
-                self::dbg(' ==== Found ' . count($tmp_quarantined) . ' quarantined e-mails');
-                if (count($tmp_quarantined) > 0) {
-                    $quarantined[] = $tmp_quarantined;
+                self::dbg(' ==== Found ' . count($quarantined) . ' quarantined e-mails');
+            }
+            else {
+                foreach ($filters as $filter) {
+                    if ('D' === $type) {
+                        $filter_domain = preg_match('/(\S+)@(\S+)/', $filter, $split) ? $split[2] : $filter;
+                        $list_for = $filter_domain;
+                    } else {
+                        $filter_domain = $to_domain;
+                        $list_for = $filter;
+                    }
+
+                    self::dbg(" ==== Building list for $list_for");
+                    $tmp_quarantined = self::return_quarantine_list_array($filter, $filter_domain);
+
+                    self::dbg(' ==== Found ' . count($tmp_quarantined) . ' quarantined e-mails');
+                    if (count($tmp_quarantined) > 0) {
+                        $quarantined[] = $tmp_quarantined;
+                        $quarantine_list[] = $list_for;
+                    }
                 }
             }
             if (count($quarantined) > 0) {


### PR DESCRIPTION
Having administrator users defined with one or more filter addresses (e.g. automatically imported from LDAP with mailwatch_ldap_sync.sh) led to quarantine reports with duplicate lines.

So when the user type is 'A' we must NOT iterate through the filters because administrators get a report for every single recipient anyway.

Also the administrator's report had an incomplete headline because a suitable string was missing ($list_for was set empty). 
I suggest using the system's hostname in this case.

For normal users, when sending **combined** reports the headline should only list the addresses which are contained in the current report. Otherwise this gets very messy when you have a lot of address filters defined for a user.