### PR TITLE
enhancement for individual nonspam quarantine keeping

### DIFF
--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -182,6 +182,7 @@ define('MAILWATCH_HOSTURL', 'https://' . rtrim(gethostname()) . '/mailscanner');
 // the clean.quarantine script provided with MailScanner.
 define('QUARANTINE_USE_FLAG', true);
 define('QUARANTINE_DAYS_TO_KEEP', 30);
+define('QUARANTINE_DAYS_TO_KEEP_NONSPAM', 30);
 //Set QUARANTINE_FILTERS_COMBINED to true to combine quarantine report into a single report when user filters are present
 define('QUARANTINE_FILTERS_COMBINED', false);
 define('QUARANTINE_REPORT_FROM_NAME', 'MailWatch for MailScanner');

--- a/tools/Cron_jobs/mailwatch_quarantine_maint.php
+++ b/tools/Cron_jobs/mailwatch_quarantine_maint.php
@@ -67,7 +67,13 @@ if (0 === $required_constant_missing_count) {
     function quarantine_clean()
     {
         $oldestspam = date('U', strtotime('-' . QUARANTINE_DAYS_TO_KEEP . ' days'));
-        $oldestnonspam = date('U', strtotime('-' . QUARANTINE_DAYS_TO_KEEP_NONSPAM . ' days'));
+        if (defined('QUARANTINE_DAYS_TO_KEEP_NONSPAM')) {
+            $oldestnonspam = date('U', strtotime('-' . QUARANTINE_DAYS_TO_KEEP_NONSPAM . ' days'));
+        }
+        else {
+            // if QUARANTINE_DAYS_TO_KEEP_NONSPAM not defined: fallback to QUARANTINE_DAYS_TO_KEEP
+            $oldestnonspam = $oldestspam;            
+        }
         $quarantine = get_conf_var('QuarantineDir');
 
         $d = dir($quarantine) or exit(php_errormsg());


### PR DESCRIPTION
I found it useful to have quarantine keeping days independently configured for **nonspam** mails.

Of course this is only relevant if you also store nonspams like this:
`Non Spam Actions = store-nonspam ...`

So with this enhancement you can for example keep the spams for 30 days but the nonspams only for let's say 10 days. 
On busy systems this can save performance and drive space.

The other way around is also possible if needed: e.g. keep spam 20 days and nonspam 40 days.