### PR TITLE
Use LDAP DN from search if prefix/suffix not defined

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -3018,6 +3018,9 @@ function ldap_authenticate($username, $password)
                 if (defined('LDAP_BIND_SUFFIX')) {
                     $user .= LDAP_BIND_SUFFIX;
                 }
+                if (!defined('LDAP_BIND_PREFIX') && !defined('LDAP_BIND_SUFFIX')) {
+                    $user=$result[0]['dn'];
+                }
 
                 if (!isset($result[0][LDAP_EMAIL_FIELD])) {
                     @trigger_error(__('ldapno03') . ' "' . LDAP_EMAIL_FIELD . '" ' . __('ldapresults03'));


### PR DESCRIPTION
Using prefix/suffix to construct ldap bind dn is not possible in case of the following LDAP scheme:
ou=Users,ou=domain1.com,ou=Mail,dc=example,dc=com
ou=Users,ou=domain2.com,ou=Mail,dc=example,dc=com
I suggest using dn from previous search results if both LDAP_BIND_PREFIX and LDAP_BIND_SUFFIX is undefined.