### PR TITLE
Update SQLBlackWhiteList.pm to allow foo@*.domain.ext

### DIFF
--- a/MailScanner_perl_scripts/SQLBlackWhiteList.pm
+++ b/MailScanner_perl_scripts/SQLBlackWhiteList.pm
@@ -238,6 +238,12 @@ sub LookupList {
 
     # $ip1, $ip2, $ip3 all end in a trailing "."
 
+    # Precompute local part once
+    my ($localpart) = split /@/, $from;
+
+    # Precompute bounce@*.subdomain patterns
+    my @patterns = map { $localpart . '@' . $_ } @subdomains;
+
     # It is in the list if either the exact address is listed,
     # the domain is listed,
     # the IP address is listed,
@@ -256,8 +262,9 @@ sub LookupList {
         return 1 if $BlackWhite->{$i}{$ip1};
         return 1 if $BlackWhite->{$i}{$ip1c};
         return 1 if $BlackWhite->{$i}{'default'};
-        foreach (@subdomains) {
-            return 1 if $BlackWhite->{$i}{$_};
+        foreach my $sub (@subdomains) {
+            return 1 if $BlackWhite->{$i}{$sub};            # *.subdomain
+            return 1 if $BlackWhite->{$i}{$localpart.'@'.$sub}; # bounce@*.subdomain
         }
     }
 


### PR DESCRIPTION
Be able to blacklist like \*.domain.ext is great, but with this little change it also allows to set less broader rules like this one foo@*.spammer.com

Why it's useful? Example:
info@random1.domain.com  is OK
info@random2.domain.com  is OK
info@random3.domain.com  is OK
ads@random1.domain.com  is bad
ads@random2.domain.com  is bad

Can be solve blacklisting only ads@*.domain.com instead of *.domain.com that would be too much.