### PR TITLE
Bad ldap password and null password in db result in error 500

### DIFF
--- a/mailscanner/checklogin.php
+++ b/mailscanner/checklogin.php
@@ -104,6 +104,12 @@ if (
     && (false === $_SESSION['user_imap'])
 ) {
     $passwordInDb = database::mysqli_result($result, 0, 'password');
+    if(!is_string($passwordInDb)) {
+       header('Location: login.php?error=baduser');
+       logFailedLogin($myusername);
+       exit;
+    }
+
     if (!password_verify($mypassword, $passwordInDb)) {
         if (!hash_equals(md5($mypassword), $passwordInDb)) {
             header('Location: login.php?error=baduser');


### PR DESCRIPTION
Hello,

When using ldap to authenticate, if a local account exists with the same email and has a NULL password in database. When entering a wrong ldap password it errors a 500 error :

```log
[Tue Apr 07 11:10:12.115371 2026] [proxy_fcgi:error] [pid 53488:tid 53518] [remote 127.0.0.1:35428] AH01071: Got error 'PHP message: PHP Fatal error: Uncaught TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, bool given in /var/www/html/mailscanner/checklogin.php:108\nStack trace:\n#0 /var/www/html/mailscanner/checklogin.php(108): hash_equals()\n#1 {main}\n thrown in /var/www/html/mailscanner/checklogin.php on line 108', referer: http://localhost/login.php
```


When a field is NULL in database, the `database::mysqli_result` function returns `false` and not `NULL` nor `"NULL"`. The variable `$passwordInDb` is never verified to be not null before comparing it to other strings. 
This result in an error in `hash_equals(...)` which requires both parameters to be strings.

The fix is then to verify if the `$passwordInDb` is false before doing any string comparison on it, and therefore exiting with a `Login failed` error.